### PR TITLE
fix: ensure localStorage is set before reloading in hidden tournament tests

### DIFF
--- a/e2e/hidden-tournament.spec.ts
+++ b/e2e/hidden-tournament.spec.ts
@@ -72,8 +72,10 @@ test.describe.serial('Hidden tournament (underscore prefix)', () => {
 
     const listPage = new TournamentListPage(page);
 
-    await page.evaluate(() => localStorage.setItem('showHidden', 'true'));
+    // Navigate first to have a valid origin, then set localStorage and reload
     await listPage.goto();
+    await page.evaluate(() => localStorage.setItem('showHidden', 'true'));
+    await page.reload();
     await listPage.waitForTournamentToAppear(tournamentName);
     expect(await listPage.hasTournament(tournamentName)).toBe(true);
   });


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>