### PR TITLE
feat(playoffs): add playoffs generation feature and UI

### DIFF
--- a/e2e/pages/phases.page.ts
+++ b/e2e/pages/phases.page.ts
@@ -172,9 +172,16 @@ export class PhasesPage {
       .filter({ has: this.page.locator('input#poule-name') });
     await dialog.waitFor({ state: 'visible' });
 
-    await dialog.locator('p-select[name="team-select"] .p-select-dropdown').click();
-    await this.page.locator('.p-select-overlay').getByText(teamName, { exact: true }).click();
-    await dialog.getByTestId('dialog-add-team-button').click();
+    const teamMultiSelect = dialog.locator('p-multiselect[name="team-select"]');
+    await teamMultiSelect.click();
+
+    const overlay = this.page.locator('.p-multiselect-overlay:visible').last();
+    await expect(overlay).toBeVisible();
+    await overlay.getByText(teamName, { exact: true }).first().click();
+
+    const addTeamButton = dialog.getByTestId('dialog-add-team-button');
+    await expect(addTeamButton).toBeEnabled();
+    await addTeamButton.click();
 
     await dialog.locator('button[type="submit"]').click();
     await dialog.waitFor({ state: 'hidden' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "txapelketak",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/cdk": "^21.2.10",
         "@angular/common": "^21.2.12",
         "@angular/compiler": "^21.2.12",
         "@angular/core": "^21.2.12",
@@ -804,6 +805,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "21.2.10",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.10.tgz",
+      "integrity": "sha512-yfCzUFNfeSMNnCkc0P5Pozqz1EViDe9KLPQyHVY/hApsNgBWvckpA+ZEWgKNfAf72f8bUJvZoHejaSMGYrpvuw==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -12119,7 +12136,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -12173,7 +12189,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
+    "@angular/cdk": "^21.2.10",
     "@angular/common": "^21.2.12",
     "@angular/compiler": "^21.2.12",
     "@angular/core": "^21.2.12",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -175,7 +175,7 @@
       "addPoule": "Add a group",
       "addPlayoffs": "Add playoffs",
       "addFreePhase": "Add a free phase",
-      "addTeam": "Add a team",
+      "addTeam": "Add",
       "noSeries": "No series available",
       "dialogAddSerie": "Add a series",
       "dialogEditSerie": "Edit series",
@@ -225,7 +225,8 @@
       "addPlayoffsComingSoon": "This feature will be available soon.",
       "teamsUpdated": "Teams updated",
       "teamsUpdatedDetail": "{{added}} team(s) added, {{removed}} team(s) removed",
-      "teamsAddedToPouleDetail": "{{count}} team(s) added to \"{{pouleName}}\"."
+      "teamsAddedToPouleDetail": "{{count}} team(s) added to \"{{pouleName}}\".",
+      "dialogAddPlayoffs": "Add playoffs"
     },
     "games": {
       "addGame": "Add a game",
@@ -374,6 +375,7 @@
       "save": "Save",
       "cancel": "Cancel",
       "next": "Next",
+      "previous": "Previous",
       "edit": "Edit",
       "delete": "Delete",
       "viewGames": "Games"
@@ -441,5 +443,16 @@
       "32": "Round of 32"
     },
     "winnerOf": "Winner of {{round}} {{match}}"
+  },
+  "playoffs": {
+    "name": "Playoffs name",
+    "step1Title": "Teams and seeding order",
+    "step2Title": "Bracket preview",
+    "noTeamsSelected": "No teams selected",
+    "bracketSize": "Bracket size: {{size}} teams",
+    "bye": "Bye",
+    "seed": "Seed {{n}}",
+    "generated": "Playoffs generated",
+    "generatedDetail": "{{count}} playoff matches have been generated."
   }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -450,6 +450,14 @@
     "step2Title": "Bracket preview",
     "noTeamsSelected": "No teams selected",
     "bracketSize": "Bracket size: {{size}} teams",
+    "matchOrganization": {
+      "label": "Match organization",
+      "help": "Linear: 1 vs 2, 3 vs 4. Competition: 1 vs N, 2 vs N-1.",
+      "options": {
+        "linear": "Linear",
+        "competition": "Competition"
+      }
+    },
     "bye": "Bye",
     "seed": "Seed {{n}}",
     "generated": "Playoffs generated",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -175,7 +175,7 @@
       "addPoule": "Añadir un grupo",
       "addPlayoffs": "Añadir playoffs",
       "addFreePhase": "Añadir una fase libre",
-      "addTeam": "Añadir un equipo",
+      "addTeam": "Añadir",
       "noSeries": "No hay series disponibles",
       "dialogAddSerie": "Añadir una serie",
       "dialogEditSerie": "Editar serie",
@@ -225,7 +225,8 @@
       "addPlayoffsComingSoon": "Esta función estará disponible pronto.",
       "teamsUpdated": "Equipos actualizados",
       "teamsUpdatedDetail": "{{added}} equipo(s) añadido(s), {{removed}} equipo(s) eliminado(s)",
-      "teamsAddedToPouleDetail": "{{count}} equipo(s) añadido(s) a \"{{pouleName}}\"."
+      "teamsAddedToPouleDetail": "{{count}} equipo(s) añadido(s) a \"{{pouleName}}\".",
+      "dialogAddPlayoffs": "Añadir playoffs"
     },
     "games": {
       "addGame": "Añadir un partido",
@@ -374,6 +375,7 @@
       "save": "Guardar",
       "cancel": "Cancelar",
       "next": "Siguiente",
+      "previous": "Anterior",
       "edit": "Editar",
       "delete": "Eliminar",
       "viewGames": "Partidos"
@@ -441,5 +443,16 @@
       "32": "Dieciseisavos de final"
     },
     "winnerOf": "Ganador de {{round}} {{match}}"
+  },
+  "playoffs": {
+    "name": "Nombre de los playoffs",
+    "step1Title": "Equipos y orden de participación",
+    "step2Title": "Vista previa del cuadro",
+    "noTeamsSelected": "No hay equipos seleccionados",
+    "bracketSize": "Tamaño del cuadro: {{size}} equipos",
+    "bye": "Exento",
+    "seed": "Cabeza de serie {{n}}",
+    "generated": "Playoffs generados",
+    "generatedDetail": "{{count}} partidas de playoffs han sido generadas."
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -450,6 +450,14 @@
     "step2Title": "Vista previa del cuadro",
     "noTeamsSelected": "No hay equipos seleccionados",
     "bracketSize": "Tamaño del cuadro: {{size}} equipos",
+    "matchOrganization": {
+      "label": "Organización de los partidos",
+      "help": "Lineal: 1 vs 2, 3 vs 4. Competición: 1 vs N, 2 vs N-1.",
+      "options": {
+        "linear": "Lineal",
+        "competition": "Competición"
+      }
+    },
     "bye": "Exento",
     "seed": "Cabeza de serie {{n}}",
     "generated": "Playoffs generados",

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -450,6 +450,14 @@
     "step2Title": "Zuhaitzaren aurrebista",
     "noTeamsSelected": "Ez dago talderik hautatuta",
     "bracketSize": "Bracket tamaina: {{size}} talde",
+    "matchOrganization": {
+      "label": "Partiden antolaketa",
+      "help": "Lineala: 1 vs 2, 3 vs 4. Lehiaketa: 1 vs N, 2 vs N-1.",
+      "options": {
+        "linear": "Lineala",
+        "competition": "Lehiaketa"
+      }
+    },
     "bye": "Salbuespena",
     "seed": "{{n}}. hazia",
     "generated": "Playoffak sortuta",

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -175,7 +175,7 @@
       "addPoule": "Multzo bat gehitu",
       "addPlayoffs": "Playoffak gehitu",
       "addFreePhase": "Fase libre bat gehitu",
-      "addTeam": "Talde bat gehitu",
+      "addTeam": "Gehitu",
       "noSeries": "Ez dago serierik",
       "dialogAddSerie": "Serie bat gehitu",
       "dialogEditSerie": "Seriea editatu",
@@ -225,7 +225,8 @@
       "addPlayoffsComingSoon": "Ezaugarri hau laster etorriko da.",
       "teamsUpdated": "Taldeak eguneratu egin dira",
       "teamsUpdatedDetail": "{{added}} talde(ak) gehituta, {{removed}} talde(ak) kendu egin dira",
-      "teamsAddedToPouleDetail": "{{count}} talde gehitu dira \"{{pouleName}}\" multzora."
+      "teamsAddedToPouleDetail": "{{count}} talde gehitu dira \"{{pouleName}}\" multzora.",
+      "dialogAddPlayoffs": "Playoffak gehitu"
     },
     "games": {
       "addGame": "Partida gehitu",
@@ -374,6 +375,7 @@
       "save": "Gorde",
       "cancel": "Utzi",
       "next": "Hurrengoa",
+      "previous": "Aurrekoa",
       "edit": "Editatu",
       "delete": "Ezabatu",
       "viewGames": "Partidak"
@@ -441,5 +443,16 @@
       "32": "32ko txanda"
     },
     "winnerOf": "{{round}} {{match}} irabazlea"
+  },
+  "playoffs": {
+    "name": "Playoff izena",
+    "step1Title": "Taldeak eta ordena",
+    "step2Title": "Zuhaitzaren aurrebista",
+    "noTeamsSelected": "Ez dago talderik hautatuta",
+    "bracketSize": "Bracket tamaina: {{size}} talde",
+    "bye": "Salbuespena",
+    "seed": "{{n}}. hazia",
+    "generated": "Playoffak sortuta",
+    "generatedDetail": "{{count}} playoff partida sortu dira."
   }
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -450,6 +450,14 @@
     "step2Title": "Aperçu de l'arbre",
     "noTeamsSelected": "Aucune équipe sélectionnée",
     "bracketSize": "Taille du bracket : {{size}} équipes",
+    "matchOrganization": {
+      "label": "Organisation des matchs",
+      "help": "Linéaire: 1 vs 2, 3 vs 4. Compétition: 1 vs N, 2 vs N-1.",
+      "options": {
+        "linear": "Linéaire",
+        "competition": "Compétition"
+      }
+    },
     "bye": "Exempt",
     "seed": "Tête de série {{n}}",
     "generated": "Playoffs générés",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -175,7 +175,7 @@
       "addPoule": "Ajouter une poule",
       "addPlayoffs": "Ajouter des playoffs",
       "addFreePhase": "Ajouter une phase libre",
-      "addTeam": "Ajouter une équipe",
+      "addTeam": "Ajouter",
       "noSeries": "Aucune série disponible",
       "dialogAddSerie": "Ajouter une série",
       "dialogEditSerie": "Modifier la série",
@@ -225,7 +225,8 @@
       "addPlayoffsComingSoon": "Cette fonctionnalité sera bientôt disponible.",
       "teamsUpdated": "Équipes mises à jour",
       "teamsUpdatedDetail": "{{added}} équipe(s) ajoutée(s), {{removed}} équipe(s) retirée(s)",
-      "teamsAddedToPouleDetail": "{{count}} équipe(s) ajoutée(s) à \"{{pouleName}}\"."
+      "teamsAddedToPouleDetail": "{{count}} équipe(s) ajoutée(s) à \"{{pouleName}}\".",
+      "dialogAddPlayoffs": "Ajouter des playoffs"
     },
     "games": {
       "addGame": "Ajouter une partie",
@@ -374,6 +375,7 @@
       "save": "Enregistrer",
       "cancel": "Annuler",
       "next": "Suivant",
+      "previous": "Précédent",
       "edit": "Modifier",
       "delete": "Supprimer",
       "viewGames": "Parties"
@@ -441,5 +443,16 @@
       "32": "Seizième de finale"
     },
     "winnerOf": "Gagnant {{round}} {{match}}"
+  },
+  "playoffs": {
+    "name": "Nom des playoffs",
+    "step1Title": "Équipes et ordre de jeu",
+    "step2Title": "Aperçu de l'arbre",
+    "noTeamsSelected": "Aucune équipe sélectionnée",
+    "bracketSize": "Taille du bracket : {{size}} équipes",
+    "bye": "Exempt",
+    "seed": "Tête de série {{n}}",
+    "generated": "Playoffs générés",
+    "generatedDetail": "{{count}} matchs de playoffs ont été générés."
   }
 }

--- a/src/app/shared/services/firebase.service.ts
+++ b/src/app/shared/services/firebase.service.ts
@@ -764,7 +764,7 @@ export class FirebaseService {
 
   async generatePlayoffsForSerie(
     serieRef: DocumentReference,
-    serieName: string,
+    playoffsName: string,
     bracketSize: number,
     orderedTeamRefs: DocumentReference[],
     matchOrganization: PlayoffsMatchOrganization,
@@ -784,7 +784,7 @@ export class FirebaseService {
       const matchCount = roundSize / 2;
       for (let matchNumber = 1; matchNumber <= matchCount; matchNumber++) {
         const gameData: Record<string, unknown> = {
-          name: `${serieName} - ${roundName} ${matchNumber}`,
+          name: `${playoffsName} - ${roundName} ${matchNumber}`,
           round: roundName,
           roundOrder: roundSize,
           matchNumber,

--- a/src/app/shared/services/firebase.service.ts
+++ b/src/app/shared/services/firebase.service.ts
@@ -23,6 +23,7 @@ import { Tournament, TournamentStatus, User } from '../../home/tournament.interf
 import { TournamentYamlData } from '../../admin/types/shared/admin-import-export/admin-import-export';
 import { Game, TimeSlot, FinaleGame } from '../../tournaments/poules.model';
 import { Team } from '../../tournaments/shared/teams/teams';
+import type { PlayoffsMatchOrganization } from '../../tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog';
 
 @Injectable({
   providedIn: 'root',
@@ -766,6 +767,7 @@ export class FirebaseService {
     serieName: string,
     bracketSize: number,
     orderedTeamRefs: DocumentReference[],
+    matchOrganization: PlayoffsMatchOrganization,
   ): Promise<void> {
     console.debug(`[Firestore] generatePlayoffsForSerie: bracketSize=${bracketSize}`);
     await this.deleteFinaleGamesForSerie(serieRef);
@@ -792,9 +794,18 @@ export class FirebaseService {
           gameData['team1Placeholder'] = `finale.winnerOf:${prevRoundName}:${2 * matchNumber - 1}`;
           gameData['team2Placeholder'] = `finale.winnerOf:${prevRoundName}:${2 * matchNumber}`;
         } else {
-          // First round: assign seeded teams linearly (match j → teams[2j-2] vs teams[2j-1])
-          const team1Ref = orderedTeamRefs[(matchNumber - 1) * 2] ?? null;
-          const team2Ref = orderedTeamRefs[(matchNumber - 1) * 2 + 1] ?? null;
+          const linearTeam1Index = (matchNumber - 1) * 2;
+          const linearTeam2Index = (matchNumber - 1) * 2 + 1;
+          const competitionTeam1Index = matchNumber - 1;
+          const competitionTeam2Index = roundSize - matchNumber;
+
+          const team1Index =
+            matchOrganization === 'competition' ? competitionTeam1Index : linearTeam1Index;
+          const team2Index =
+            matchOrganization === 'competition' ? competitionTeam2Index : linearTeam2Index;
+
+          const team1Ref = orderedTeamRefs[team1Index] ?? null;
+          const team2Ref = orderedTeamRefs[team2Index] ?? null;
           if (team1Ref) gameData['refTeam1'] = team1Ref;
           if (team2Ref) gameData['refTeam2'] = team2Ref;
         }

--- a/src/app/shared/services/firebase.service.ts
+++ b/src/app/shared/services/firebase.service.ts
@@ -761,6 +761,53 @@ export class FirebaseService {
     }
   }
 
+  async generatePlayoffsForSerie(
+    serieRef: DocumentReference,
+    serieName: string,
+    bracketSize: number,
+    orderedTeamRefs: DocumentReference[],
+  ): Promise<void> {
+    console.debug(`[Firestore] generatePlayoffsForSerie: bracketSize=${bracketSize}`);
+    await this.deleteFinaleGamesForSerie(serieRef);
+
+    const allRoundNames: { name: string; size: number }[] = [];
+    let currentSize = bracketSize;
+    while (currentSize >= 2) {
+      allRoundNames.push({ name: this.getRoundName(currentSize), size: currentSize });
+      currentSize = Math.floor(currentSize / 2);
+    }
+
+    let prevRoundName: string | null = null;
+    for (const { name: roundName, size: roundSize } of allRoundNames) {
+      const matchCount = roundSize / 2;
+      for (let matchNumber = 1; matchNumber <= matchCount; matchNumber++) {
+        const gameData: Record<string, unknown> = {
+          name: `${serieName} - ${roundName} ${matchNumber}`,
+          round: roundName,
+          roundOrder: roundSize,
+          matchNumber,
+        };
+        if (prevRoundName) {
+          // Subsequent rounds: winner placeholders
+          gameData['team1Placeholder'] = `finale.winnerOf:${prevRoundName}:${2 * matchNumber - 1}`;
+          gameData['team2Placeholder'] = `finale.winnerOf:${prevRoundName}:${2 * matchNumber}`;
+        } else {
+          // First round: assign seeded teams linearly (match j → teams[2j-2] vs teams[2j-1])
+          const team1Ref = orderedTeamRefs[(matchNumber - 1) * 2] ?? null;
+          const team2Ref = orderedTeamRefs[(matchNumber - 1) * 2 + 1] ?? null;
+          if (team1Ref) gameData['refTeam1'] = team1Ref;
+          if (team2Ref) gameData['refTeam2'] = team2Ref;
+        }
+        const gameDocRef = doc(collection(serieRef, 'finaleGames'));
+        await runInInjectionContext(this.environmentInjector, async () => {
+          console.debug(`[Firestore] setDoc: finaleGame (playoffs)`);
+          await setDoc(gameDocRef, gameData);
+        });
+      }
+      prevRoundName = roundName;
+    }
+  }
+
   async deleteFinaleGamesForSerie(serieRef: DocumentReference): Promise<void> {
     console.debug(`[Firestore] deleteFinaleGamesForSerie`);
     const gameDocs = await this.getCollectionFromDocumentRef(serieRef, 'finaleGames');

--- a/src/app/shared/services/tournament-actions.service.ts
+++ b/src/app/shared/services/tournament-actions.service.ts
@@ -356,6 +356,7 @@ export class TournamentActionsService {
       event.name,
       event.size,
       event.orderedTeamRefs,
+      event.matchOrganization,
     );
     const count = event.size - 1;
     this.messageService.add({

--- a/src/app/shared/services/tournament-actions.service.ts
+++ b/src/app/shared/services/tournament-actions.service.ts
@@ -20,6 +20,7 @@ import {
   SaveFinaleGameEvent,
   SetFinaleSizeEvent,
 } from '../../tournaments/shared/phases/phases';
+import { SavePlayoffsEvent } from '../../tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog';
 import { Game, Serie } from '../../tournaments/poules.model';
 import { Team } from '../../tournaments/shared/teams/teams';
 
@@ -346,6 +347,21 @@ export class TournamentActionsService {
       severity: 'success',
       summary: this.translocoService.translate('finale.gameEdited'),
       detail: this.translocoService.translate('finale.gameEditedDetail'),
+    });
+  }
+
+  async generatePlayoffs(event: SavePlayoffsEvent): Promise<void> {
+    await this.firebaseService.generatePlayoffsForSerie(
+      event.serieRef,
+      event.name,
+      event.size,
+      event.orderedTeamRefs,
+    );
+    const count = event.size - 1;
+    this.messageService.add({
+      severity: 'success',
+      summary: this.translocoService.translate('playoffs.generated'),
+      detail: this.translocoService.translate('playoffs.generatedDetail', { count }),
     });
   }
 }

--- a/src/app/tournaments/shared/phases/phases.html
+++ b/src/app/tournaments/shared/phases/phases.html
@@ -66,7 +66,7 @@
                 severity="primary"
                 icon="pi pi-plus"
                 [label]="'admin.poules.addFreePhase' | transloco"
-                (onClick)="onAddPlayoffs(serie.ref)"
+                (onClick)="onAddFreePhase(serie.ref)"
                 data-testid="add-free-phase-button"
               />
             </div>

--- a/src/app/tournaments/shared/phases/phases.ts
+++ b/src/app/tournaments/shared/phases/phases.ts
@@ -424,6 +424,11 @@ export class Phases {
       if (result) {
         console.log('Playoffs to save', result);
         //void this.tournamentActions.generatePlayoffs(result);
+        this.messageService.add({
+          severity: 'info',
+          summary: this.translocoService.translate('admin.poules.comingSoon'),
+          detail: this.translocoService.translate('admin.poules.addPlayoffsComingSoon'),
+        });
       }
     });
   }

--- a/src/app/tournaments/shared/phases/phases.ts
+++ b/src/app/tournaments/shared/phases/phases.ts
@@ -21,6 +21,7 @@ import {
   FinaleGameFormDialog,
   SaveFinaleGameEvent,
 } from './finale-game-form-dialog/finale-game-form-dialog';
+import { PlayoffsFormDialog, SavePlayoffsEvent } from './playoffs-form-dialog/playoffs-form-dialog';
 
 export type { SaveFinaleGameEvent };
 import { PoulesStore } from '../../../store/poules.store';
@@ -412,7 +413,23 @@ export class Phases {
   }
 
   onAddPlayoffs(serieRef: DocumentReference): void {
-    console.log('Add playoffs for serie', serieRef);
+    const dialogRef = this.dialogService.open(PlayoffsFormDialog, {
+      header: this.translocoService.translate('admin.poules.dialogAddPlayoffs'),
+      modal: true,
+      closable: true,
+      width: 'min(60rem, 100%)',
+      data: { serieRef, teams: this.teams() },
+    });
+    dialogRef?.onClose.subscribe((result: SavePlayoffsEvent | undefined) => {
+      if (result) {
+        console.log('Playoffs to save', result);
+        //void this.tournamentActions.generatePlayoffs(result);
+      }
+    });
+  }
+
+  onAddFreePhase(serieRef: DocumentReference): void {
+    console.log('Add free phase for serie', serieRef);
     this.messageService.add({
       severity: 'info',
       summary: this.translocoService.translate('admin.poules.comingSoon'),

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.css
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.css
@@ -1,0 +1,101 @@
+:host {
+  --playoffs-tree-column-width: 16rem;
+  --playoffs-tree-slot-height: 5.75rem;
+  --playoffs-tree-row-gap: 0.875rem;
+  --playoffs-tree-round-gap: 2rem;
+  --playoffs-tree-connector-color: var(--p-content-border-color);
+}
+
+.playoffs-tree-wrapper {
+  overflow-x: auto;
+  padding: 0.5rem 0.25rem;
+}
+
+.playoffs-tree {
+  display: grid;
+  grid-template-columns: repeat(
+    var(--playoffs-tree-round-count),
+    var(--playoffs-tree-column-width)
+  );
+  gap: calc(var(--playoffs-tree-round-gap) + 0.5 * var(--playoffs-tree-round-gap));
+  min-width: max-content;
+}
+
+.playoffs-tree-round {
+  display: flex;
+  flex-direction: column;
+  min-width: var(--playoffs-tree-column-width);
+}
+
+.playoffs-tree-round-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  margin: 0 0 0.5rem;
+  color: var(--p-text-muted-color);
+  white-space: nowrap;
+}
+
+.playoffs-tree-round-lane {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(
+    var(--playoffs-tree-slot-count),
+    calc(var(--playoffs-tree-slot-height) + var(--playoffs-tree-row-gap))
+  );
+}
+
+.playoffs-tree-match {
+  position: relative;
+  grid-row-start: var(--playoffs-tree-grid-row);
+  grid-row-end: span var(--playoffs-tree-slot-span);
+  display: flex;
+  align-items: center;
+}
+
+.playoffs-tree-match--with-connector::before {
+  content: '';
+  position: absolute;
+  right: calc(-1 * var(--playoffs-tree-round-gap));
+  top: 50%;
+  width: var(--playoffs-tree-round-gap);
+  border-top: 1px solid var(--playoffs-tree-connector-color);
+  transform: translateY(-50%);
+}
+
+.playoffs-tree-connector {
+  position: absolute;
+  right: calc(-1 * var(--playoffs-tree-round-gap));
+  top: 50%;
+  height: calc(
+    var(--playoffs-tree-slot-span) *
+      (var(--playoffs-tree-slot-height) + var(--playoffs-tree-row-gap)) / 2
+  );
+  border-right: 1px solid var(--playoffs-tree-connector-color);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.playoffs-tree-match--with-connector:nth-child(odd) {
+  .playoffs-tree-connector {
+    top: 75%;
+  }
+}
+
+.playoffs-tree-match--with-connector:nth-child(even) {
+  .playoffs-tree-connector {
+    top: 25%;
+  }
+}
+
+.finale-match {
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  :host {
+    --playoffs-tree-column-width: 14.5rem;
+    --playoffs-tree-round-gap: 1.5rem;
+    --playoffs-tree-slot-height: 5.5rem;
+  }
+}

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.css
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.css
@@ -13,10 +13,8 @@
 
 .playoffs-tree {
   display: grid;
-  grid-template-columns: repeat(
-    var(--playoffs-tree-round-count),
-    var(--playoffs-tree-column-width)
-  );
+  grid-auto-flow: column;
+  grid-auto-columns: var(--playoffs-tree-column-width);
   gap: calc(var(--playoffs-tree-round-gap) + 0.5 * var(--playoffs-tree-round-gap));
   min-width: max-content;
 }
@@ -39,10 +37,7 @@
 .playoffs-tree-round-lane {
   position: relative;
   display: grid;
-  grid-template-rows: repeat(
-    var(--playoffs-tree-slot-count),
-    calc(var(--playoffs-tree-slot-height) + var(--playoffs-tree-row-gap))
-  );
+  grid-auto-rows: calc(var(--playoffs-tree-slot-height) + var(--playoffs-tree-row-gap));
 }
 
 .playoffs-tree-match {

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
@@ -80,6 +80,25 @@
         <p-message severity="info" class="w-full mt-2" data-testid="playoffs-dialog-bracket-size">
           {{ 'playoffs.bracketSize' | transloco: { size: bracketSize() } }}
         </p-message>
+
+        <div class="mt-4 flex flex-col gap-2" data-testid="playoffs-dialog-match-organization">
+          <label class="text-sm font-medium" for="playoffs-match-organization">
+            {{ 'playoffs.matchOrganization.label' | transloco }}
+          </label>
+          <p-selectbutton
+            id="playoffs-match-organization"
+            [options]="matchOrganizationOptions()"
+            [ngModel]="matchOrganization()"
+            (ngModelChange)="matchOrganization.set($event)"
+            optionLabel="label"
+            optionValue="value"
+            [allowEmpty]="false"
+            data-testid="playoffs-dialog-match-organization-select"
+          />
+          <small class="text-surface-500">
+            {{ 'playoffs.matchOrganization.help' | transloco }}
+          </small>
+        </div>
       }
     </div>
 

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
@@ -131,27 +131,56 @@
       {{ 'playoffs.bracketSize' | transloco: { size: bracketSize() } }}
     </p>
 
-    <div class="finale-bracket" data-testid="playoffs-dialog-bracket-preview">
-      @for (round of bracketPreview(); track round.roundLabel) {
-        <div class="finale-round">
-          <h4 class="finale-round-title">{{ round.roundLabel | transloco }}</h4>
-          @for (match of round.matches; track match.matchNumber) {
-            <div class="finale-match">
-              <div class="finale-match-header">
-                <span class="text-xs"
-                  >{{ 'finale.matchLabel' | transloco }} {{ match.matchNumber }}</span
+    <div class="playoffs-tree-wrapper" data-testid="playoffs-dialog-bracket-preview-wrapper">
+      <div
+        class="playoffs-tree"
+        data-testid="playoffs-dialog-bracket-preview"
+        [ngStyle]="bracketTreeStyle()"
+      >
+        @for (round of bracketTreeRounds(); track round.roundLabel) {
+          <div class="playoffs-tree-round" data-testid="playoffs-dialog-bracket-round-column">
+            <h4 class="playoffs-tree-round-title">{{ round.roundLabel | transloco }}</h4>
+            <div class="playoffs-tree-round-lane">
+              @for (match of round.matches; track match.data.matchNumber) {
+                <div
+                  class="playoffs-tree-match"
+                  [class.playoffs-tree-match--with-connector]="!round.isFinalRound"
+                  [style.--playoffs-tree-grid-row]="match.gridRow"
+                  [style.--playoffs-tree-slot-span]="match.slotSpan"
+                  data-testid="playoffs-dialog-bracket-match"
                 >
-              </div>
-              <div class="finale-match-team" [class.opacity-50]="match.isBye && !match.team1Name">
-                <span class="finale-team-name">{{ match.team1Name }}</span>
-              </div>
-              <div class="finale-match-team" [class.opacity-50]="match.isBye && !match.team2Name">
-                <span class="finale-team-name">{{ match.team2Name }}</span>
-              </div>
+                  <div class="finale-match">
+                    <div class="finale-match-header">
+                      <span class="text-xs"
+                        >{{ 'finale.matchLabel' | transloco }} {{ match.data.matchNumber }}</span
+                      >
+                    </div>
+                    <div
+                      class="finale-match-team"
+                      [class.opacity-50]="match.data.isBye && !match.data.team1Name"
+                    >
+                      <span class="finale-team-name">{{ match.data.team1Name }}</span>
+                    </div>
+                    <div
+                      class="finale-match-team"
+                      [class.opacity-50]="match.data.isBye && !match.data.team2Name"
+                    >
+                      <span class="finale-team-name">{{ match.data.team2Name }}</span>
+                    </div>
+                  </div>
+                  @if (!round.isFinalRound) {
+                    <span
+                      class="playoffs-tree-connector"
+                      aria-hidden="true"
+                      data-testid="playoffs-dialog-bracket-connector"
+                    ></span>
+                  }
+                </div>
+              }
             </div>
-          }
-        </div>
-      }
+          </div>
+        }
+      </div>
     </div>
 
     <div class="p-dialog-footer px-0! mt-5 flex items-center justify-end gap-2">

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.html
@@ -1,0 +1,163 @@
+<!-- Step 1: Name + team selection and ordering -->
+@if (currentStep() === 1) {
+  <div>
+    <div class="mb-4">
+      <p-floatlabel variant="on">
+        <input
+          pInputText
+          id="playoffs-name"
+          class="w-full"
+          autocomplete="off"
+          [ngModel]="playoffsName()"
+          (ngModelChange)="playoffsName.set($event)"
+          name="playoffs-name"
+        />
+        <label for="playoffs-name">{{ 'playoffs.name' | transloco }}</label>
+      </p-floatlabel>
+    </div>
+
+    <div class="mb-4">
+      <h5 class="text-lg font-semibold mb-2">{{ 'playoffs.step1Title' | transloco }}</h5>
+
+      <div class="flex gap-2 items-center mb-3">
+        <p-multiselect
+          class="flex-1"
+          [options]="availableTeams()"
+          optionLabel="value"
+          optionValue="key"
+          [placeholder]="'admin.poules.selectTeam' | transloco"
+          display="chip"
+          [ngModel]="pendingTeamRef()"
+          (ngModelChange)="pendingTeamRef.set($event)"
+          name="team-select"
+          appendTo="body"
+          [filter]="true"
+          [showClear]="true"
+        />
+        <p-button
+          type="button"
+          severity="primary"
+          icon="pi pi-plus"
+          [label]="'admin.poules.addTeam' | transloco"
+          [disabled]="pendingTeamRef().length === 0"
+          (onClick)="onAddSelectedTeam()"
+          data-testid="playoffs-dialog-add-team-button"
+        />
+      </div>
+
+      @if (selectedTeams().length === 0) {
+        <p-message severity="info" class="w-full" data-testid="playoffs-dialog-no-team-message">
+          {{ 'playoffs.noTeamsSelected' | transloco }}
+        </p-message>
+      } @else {
+        <p-orderlist
+          [value]="selectedTeams()"
+          dataKey="key"
+          [dragdrop]="true"
+          [listStyle]="{ 'max-height': '16rem' }"
+          data-testid="playoffs-dialog-order-list"
+        >
+          <ng-template #item let-team let-index="index">
+            <div class="flex items-center justify-between w-full gap-2">
+              <span class="font-medium text-sm text-surface-500 min-w-6">{{ index + 1 }}.</span>
+              <span class="flex-1">{{ team.value }}</span>
+              <p-button
+                type="button"
+                size="small"
+                severity="danger"
+                [outlined]="true"
+                icon="pi pi-times"
+                [ariaLabel]="'admin.poules.removeTeamAria' | transloco"
+                [pTooltip]="'admin.poules.removeTeamAria' | transloco"
+                tooltipPosition="top"
+                (onClick)="onRemoveTeam(team)"
+                data-testid="playoffs-dialog-remove-team-button"
+              />
+            </div>
+          </ng-template>
+        </p-orderlist>
+
+        <p-message severity="info" class="w-full mt-2" data-testid="playoffs-dialog-bracket-size">
+          {{ 'playoffs.bracketSize' | transloco: { size: bracketSize() } }}
+        </p-message>
+      }
+    </div>
+
+    <div class="p-dialog-footer px-0! mt-5 flex items-center justify-end gap-2">
+      <p-button
+        type="button"
+        [label]="'shared.actions.cancel' | transloco"
+        severity="secondary"
+        (onClick)="onCancel()"
+        data-testid="playoffs-dialog-cancel-button"
+      />
+      <p-button
+        type="button"
+        [label]="'shared.actions.next' | transloco"
+        icon="pi pi-arrow-right"
+        iconPos="right"
+        [disabled]="!canGoNext()"
+        (onClick)="onNext()"
+        data-testid="playoffs-dialog-next-button"
+      />
+    </div>
+  </div>
+}
+
+<!-- Step 2: Bracket preview -->
+@if (currentStep() === 2) {
+  <div>
+    <h5 class="text-lg font-semibold mb-3">{{ 'playoffs.step2Title' | transloco }}</h5>
+    <p class="text-sm text-surface-500 mb-4">
+      {{ 'playoffs.bracketSize' | transloco: { size: bracketSize() } }}
+    </p>
+
+    <div class="finale-bracket" data-testid="playoffs-dialog-bracket-preview">
+      @for (round of bracketPreview(); track round.roundLabel) {
+        <div class="finale-round">
+          <h4 class="finale-round-title">{{ round.roundLabel | transloco }}</h4>
+          @for (match of round.matches; track match.matchNumber) {
+            <div class="finale-match">
+              <div class="finale-match-header">
+                <span class="text-xs"
+                  >{{ 'finale.matchLabel' | transloco }} {{ match.matchNumber }}</span
+                >
+              </div>
+              <div class="finale-match-team" [class.opacity-50]="match.isBye && !match.team1Name">
+                <span class="finale-team-name">{{ match.team1Name }}</span>
+              </div>
+              <div class="finale-match-team" [class.opacity-50]="match.isBye && !match.team2Name">
+                <span class="finale-team-name">{{ match.team2Name }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+
+    <div class="p-dialog-footer px-0! mt-5 flex items-center justify-end gap-2">
+      <p-button
+        type="button"
+        [label]="'shared.actions.cancel' | transloco"
+        severity="secondary"
+        (onClick)="onCancel()"
+        data-testid="playoffs-dialog-cancel-button-step2"
+      />
+      <p-button
+        type="button"
+        [label]="'shared.actions.previous' | transloco"
+        icon="pi pi-arrow-left"
+        severity="secondary"
+        (onClick)="onBack()"
+        data-testid="playoffs-dialog-back-button"
+      />
+      <p-button
+        type="button"
+        [label]="'shared.actions.save' | transloco"
+        icon="pi pi-check"
+        (onClick)="onSave()"
+        data-testid="playoffs-dialog-save-button"
+      />
+    </div>
+  </div>
+}

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
@@ -249,12 +249,12 @@ describe('PlayoffsFormDialog', () => {
     component.selectedTeams.set(teams.map(asSelectedTeam));
 
     const treeRounds = component.bracketTreeRounds();
-    // Round 0 (first round): 2 matches, slotSpan=1, gridRow = (2*i+1)*1
+    // Round 0 (first round): 2 matches, slotSpan=1, gridRow = i*1 + 1
     expect(treeRounds[0].matches[0].gridRow).toBe(1);
-    expect(treeRounds[0].matches[1].gridRow).toBe(3);
+    expect(treeRounds[0].matches[1].gridRow).toBe(2);
     expect(treeRounds[0].matches[0].slotSpan).toBe(1);
-    // Round 1 (final): 1 match, slotSpan=2, gridRow = (2*0+1)*2 = 2
-    expect(treeRounds[1].matches[0].gridRow).toBe(2);
+    // Round 1 (final): 1 match, slotSpan=2, gridRow = 0*2 + 1 = 1
+    expect(treeRounds[1].matches[0].gridRow).toBe(1);
     expect(treeRounds[1].matches[0].slotSpan).toBe(2);
   });
 

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
@@ -1,0 +1,213 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DocumentReference } from '@angular/fire/firestore';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { PlayoffsFormDialog } from './playoffs-form-dialog';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { provideTranslocoTesting } from '../../../../testing/transloco-testing.providers';
+
+const asSelectedTeam = (team: { ref: DocumentReference; name: string }) => ({
+  key: team.ref.id,
+  value: team.name,
+});
+
+describe('PlayoffsFormDialog', () => {
+  let component: PlayoffsFormDialog;
+  let fixture: ComponentFixture<PlayoffsFormDialog>;
+  let mockRef: { close: ReturnType<typeof vi.fn> };
+
+  const serieRef = { id: 'serie-1' } as DocumentReference;
+  const teamARef = { id: 'team-a' } as DocumentReference;
+  const teamBRef = { id: 'team-b' } as DocumentReference;
+  const teamCRef = { id: 'team-c' } as DocumentReference;
+  const teamDRef = { id: 'team-d' } as DocumentReference;
+
+  const teams = [
+    { ref: teamARef, name: 'Team A' },
+    { ref: teamBRef, name: 'Team B' },
+    { ref: teamCRef, name: 'Team C' },
+    { ref: teamDRef, name: 'Team D' },
+  ];
+
+  beforeEach(async () => {
+    mockRef = { close: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [PlayoffsFormDialog],
+      providers: [
+        provideAnimationsAsync(),
+        ...provideTranslocoTesting(),
+        {
+          provide: DynamicDialogConfig,
+          useValue: {
+            data: { serieRef, teams },
+          },
+        },
+        { provide: DynamicDialogRef, useValue: mockRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlayoffsFormDialog);
+    fixture.detectChanges();
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should start on step 1', () => {
+    expect(component.currentStep()).toBe(1);
+  });
+
+  it('should close dialog on cancel', () => {
+    component.onCancel();
+    expect(mockRef.close).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should not go to step 2 when name is empty', () => {
+    component.playoffsName.set('');
+    component.selectedTeams.set([asSelectedTeam(teams[0])]);
+    component.onNext();
+    expect(component.currentStep()).toBe(1);
+  });
+
+  it('should not go to step 2 when no teams selected', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([]);
+    component.onNext();
+    expect(component.currentStep()).toBe(1);
+  });
+
+  it('canGoNext is false when name empty and no teams', () => {
+    component.playoffsName.set('');
+    component.selectedTeams.set([]);
+    expect(component.canGoNext()).toBe(false);
+  });
+
+  it('canGoNext is true when name and teams provided', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([asSelectedTeam(teams[0])]);
+    expect(component.canGoNext()).toBe(true);
+  });
+
+  it('should go to step 2 when name and teams are set', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    component.onNext();
+    expect(component.currentStep()).toBe(2);
+  });
+
+  it('should go back to step 1 from step 2', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    component.onNext();
+    component.onBack();
+    expect(component.currentStep()).toBe(1);
+  });
+
+  it('should add a team when a ref is pending', () => {
+    component.pendingTeamRef.set([teamARef.id]);
+    component.onAddSelectedTeam();
+    expect(component.selectedTeams().length).toBe(1);
+    expect(component.selectedTeams()[0].value).toBe('Team A');
+    expect(component.pendingTeamRef()).toEqual([]);
+  });
+
+  it('should not add a duplicate team', () => {
+    component.selectedTeams.set([asSelectedTeam(teams[0])]);
+    component.pendingTeamRef.set([teamARef.id]);
+    component.onAddSelectedTeam();
+    expect(component.selectedTeams().length).toBe(1);
+  });
+
+  it('should add multiple teams when refs are pending', () => {
+    component.pendingTeamRef.set([teamARef.id, teamBRef.id]);
+    component.onAddSelectedTeam();
+    expect(component.selectedTeams()).toEqual([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    expect(component.pendingTeamRef()).toEqual([]);
+  });
+
+  it('should remove a team', () => {
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    component.onRemoveTeam(asSelectedTeam(teams[0]));
+    expect(component.selectedTeams().length).toBe(1);
+    expect(component.selectedTeams()[0].value).toBe('Team B');
+  });
+
+  it('should compute bracket size as next power of 2', () => {
+    component.selectedTeams.set([asSelectedTeam(teams[0])]);
+    expect(component.bracketSize()).toBe(2);
+
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    expect(component.bracketSize()).toBe(2);
+
+    component.selectedTeams.set([
+      asSelectedTeam(teams[0]),
+      asSelectedTeam(teams[1]),
+      asSelectedTeam(teams[2]),
+    ]);
+    expect(component.bracketSize()).toBe(4);
+
+    component.selectedTeams.set(teams.map(asSelectedTeam)); // 4 teams
+    expect(component.bracketSize()).toBe(4);
+  });
+
+  it('should not save when name is empty', () => {
+    component.playoffsName.set('');
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    component.onSave();
+    expect(mockRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should not save when no teams selected', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([]);
+    component.onSave();
+    expect(mockRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should close with playoffs event on save', () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    component.onSave();
+    const result = mockRef.close.mock.calls[0][0];
+    expect(result.name).toBe('My Playoffs');
+    expect(result.serieRef).toBeDefined();
+    expect(result.orderedTeamRefs).toHaveLength(2);
+    expect(result.size).toBe(2);
+  });
+
+  it('should compute bracket preview for first round with actual teams', () => {
+    component.selectedTeams.set([asSelectedTeam(teams[0]), asSelectedTeam(teams[1])]);
+    const preview = component.bracketPreview();
+    // size=2 → 1 round (Finale), 1 match
+    const firstRound = preview.find((r) => r.roundOrder === 2);
+    expect(firstRound).toBeDefined();
+    expect(firstRound!.matches[0].team1Name).toBe('Team A');
+    expect(firstRound!.matches[0].team2Name).toBe('Team B');
+  });
+
+  it('should show bye for missing team slots', () => {
+    // 3 teams → bracketSize=4, first round has 2 matches (4/2=2)
+    // Match 1: team[0] vs team[1], Match 2: team[2] vs bye
+    component.selectedTeams.set([
+      asSelectedTeam(teams[0]),
+      asSelectedTeam(teams[1]),
+      asSelectedTeam(teams[2]),
+    ]);
+    const preview = component.bracketPreview();
+    const firstRound = preview.find((r) => r.roundOrder === 4);
+    expect(firstRound).toBeDefined();
+    expect(firstRound!.matches).toHaveLength(2);
+    expect(firstRound!.matches[1].isBye).toBe(true);
+  });
+
+  it('should exclude already-selected teams from availableTeams', () => {
+    component.selectedTeams.set([asSelectedTeam(teams[0])]);
+    const available = component.availableTeams();
+    expect(available.some((t) => t.key === teamARef.id)).toBe(false);
+    expect(available.length).toBe(3);
+  });
+});

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
@@ -61,6 +61,10 @@ describe('PlayoffsFormDialog', () => {
     expect(component.currentStep()).toBe(1);
   });
 
+  it('should default match organization to linear', () => {
+    expect(component.matchOrganization()).toBe('linear');
+  });
+
   it('should close dialog on cancel', () => {
     component.onCancel();
     expect(mockRef.close).toHaveBeenCalledWith(undefined);
@@ -177,6 +181,19 @@ describe('PlayoffsFormDialog', () => {
     expect(result.serieRef).toBeDefined();
     expect(result.orderedTeamRefs).toHaveLength(2);
     expect(result.size).toBe(2);
+    expect(result.matchOrganization).toBe('linear');
+  });
+
+  it('should keep selected team order in save payload', () => {
+    component.playoffsName.set('My Playoffs');
+    component.matchOrganization.set('competition');
+    component.selectedTeams.set([asSelectedTeam(teams[2]), asSelectedTeam(teams[0])]);
+    component.onSave();
+
+    const result = mockRef.close.mock.calls[0][0];
+    expect(result.orderedTeamRefs[0].id).toBe(teamCRef.id);
+    expect(result.orderedTeamRefs[1].id).toBe(teamARef.id);
+    expect(result.matchOrganization).toBe('competition');
   });
 
   it('should compute bracket preview for first round with actual teams', () => {
@@ -202,6 +219,19 @@ describe('PlayoffsFormDialog', () => {
     expect(firstRound).toBeDefined();
     expect(firstRound!.matches).toHaveLength(2);
     expect(firstRound!.matches[1].isBye).toBe(true);
+  });
+
+  it('should compute first round in competition mode', () => {
+    component.matchOrganization.set('competition');
+    component.selectedTeams.set(teams.map(asSelectedTeam));
+
+    const preview = component.bracketPreview();
+    const firstRound = preview.find((r) => r.roundOrder === 4);
+    expect(firstRound).toBeDefined();
+    expect(firstRound!.matches[0].team1Name).toBe('Team A');
+    expect(firstRound!.matches[0].team2Name).toBe('Team D');
+    expect(firstRound!.matches[1].team1Name).toBe('Team B');
+    expect(firstRound!.matches[1].team2Name).toBe('Team C');
   });
 
   it('should exclude already-selected teams from availableTeams', () => {

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.spec.ts
@@ -234,6 +234,49 @@ describe('PlayoffsFormDialog', () => {
     expect(firstRound!.matches[1].team2Name).toBe('Team C');
   });
 
+  it('should compute tree rounds with final round as last column', () => {
+    component.selectedTeams.set(teams.map(asSelectedTeam));
+
+    const treeRounds = component.bracketTreeRounds();
+    expect(treeRounds).toHaveLength(2);
+    expect(treeRounds[0].roundOrder).toBe(4);
+    expect(treeRounds[0].isFinalRound).toBe(false);
+    expect(treeRounds[1].roundOrder).toBe(2);
+    expect(treeRounds[1].isFinalRound).toBe(true);
+  });
+
+  it('should compute centered tree match slot positions across rounds', () => {
+    component.selectedTeams.set(teams.map(asSelectedTeam));
+
+    const treeRounds = component.bracketTreeRounds();
+    // Round 0 (first round): 2 matches, slotSpan=1, gridRow = (2*i+1)*1
+    expect(treeRounds[0].matches[0].gridRow).toBe(1);
+    expect(treeRounds[0].matches[1].gridRow).toBe(3);
+    expect(treeRounds[0].matches[0].slotSpan).toBe(1);
+    // Round 1 (final): 1 match, slotSpan=2, gridRow = (2*0+1)*2 = 2
+    expect(treeRounds[1].matches[0].gridRow).toBe(2);
+    expect(treeRounds[1].matches[0].slotSpan).toBe(2);
+  });
+
+  it('should render bracket columns and connectors in step 2', async () => {
+    component.playoffsName.set('My Playoffs');
+    component.selectedTeams.set(teams.map(asSelectedTeam));
+    component.onNext();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(
+      element.querySelectorAll('[data-testid="playoffs-dialog-bracket-round-column"]').length,
+    ).toBe(2);
+    expect(element.querySelectorAll('[data-testid="playoffs-dialog-bracket-match"]').length).toBe(
+      3,
+    );
+    expect(
+      element.querySelectorAll('[data-testid="playoffs-dialog-bracket-connector"]').length,
+    ).toBe(2);
+  });
+
   it('should exclude already-selected teams from availableTeams', () => {
     component.selectedTeams.set([asSelectedTeam(teams[0])]);
     const available = component.availableTeams();

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
@@ -1,0 +1,217 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DocumentReference } from '@angular/fire/firestore';
+import { Button } from 'primeng/button';
+import { FloatLabel } from 'primeng/floatlabel';
+import { InputTextModule } from 'primeng/inputtext';
+import { Message } from 'primeng/message';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { TooltipModule } from 'primeng/tooltip';
+import { OrderListModule } from 'primeng/orderlist';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import type { Team } from '../../teams/teams';
+import { KeyValue } from '@angular/common';
+
+export interface SavePlayoffsEvent {
+  serieRef: DocumentReference;
+  name: string;
+  orderedTeamRefs: DocumentReference[];
+  size: number;
+}
+
+interface PlayoffsFormDialogData {
+  serieRef: DocumentReference;
+  teams: Team[];
+}
+
+export interface BracketPreviewMatch {
+  matchNumber: number;
+  team1Name: string;
+  team2Name: string;
+  isBye: boolean;
+}
+
+export interface BracketPreviewRound {
+  roundLabel: string;
+  roundOrder: number;
+  matches: BracketPreviewMatch[];
+}
+
+function nextPowerOf2(n: number): number {
+  if (n <= 0) return 2;
+  let power = 1;
+  while (power < n) power *= 2;
+  return power;
+}
+
+function getRoundLabel(size: number): string {
+  return `finale.rounds.${size}`;
+}
+
+@Component({
+  selector: 'app-playoffs-form-dialog',
+  imports: [
+    FormsModule,
+    FloatLabel,
+    InputTextModule,
+    Button,
+    TranslocoPipe,
+    MultiSelectModule,
+    Message,
+    TooltipModule,
+    OrderListModule,
+  ],
+  templateUrl: './playoffs-form-dialog.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PlayoffsFormDialog {
+  private readonly config =
+    inject<DynamicDialogConfig<PlayoffsFormDialogData>>(DynamicDialogConfig);
+  private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly translocoService = inject(TranslocoService);
+
+  data = this.config.data ?? {
+    serieRef: null!,
+    teams: [],
+  };
+
+  currentStep = signal<1 | 2>(1);
+  playoffsName = signal('');
+  selectedTeams = signal<KeyValue<string, string>[]>([]);
+  pendingTeamRef = signal<string[]>([]);
+
+  availableTeams = computed<KeyValue<string, string>[]>(() => {
+    const selectedIds = new Set(this.selectedTeams().map((t) => t.key));
+    return this.data.teams
+      .filter((team) => !selectedIds.has(team.ref.id))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((team) => ({ value: team.name, key: team.ref.id }));
+  });
+
+  bracketSize = computed(() => {
+    const size = nextPowerOf2(this.selectedTeams().length);
+    return size > 2 ? size : 2; // Minimum size is 2 for a final match
+  });
+
+  bracketPreview = computed((): BracketPreviewRound[] => {
+    const teams = this.selectedTeams();
+    const size = this.bracketSize();
+    const rounds: BracketPreviewRound[] = [];
+
+    // Generate all rounds from first round (largest) down to final
+    let currentSize = size;
+    let prevRoundLabel: string | null = null;
+
+    while (currentSize >= 2) {
+      const roundLabel = getRoundLabel(currentSize);
+      const matchCount = currentSize / 2;
+      const matches: BracketPreviewMatch[] = [];
+
+      for (let matchNumber = 1; matchNumber <= matchCount; matchNumber++) {
+        if (prevRoundLabel === null) {
+          // First round: assign teams linearly
+          const team1Index = (matchNumber - 1) * 2;
+          const team2Index = (matchNumber - 1) * 2 + 1;
+          const team1 = teams[team1Index];
+          const team2 = teams[team2Index];
+          const team1Name = team1?.value ?? this.translocoService.translate('playoffs.bye');
+          const team2Name = team2?.value ?? this.translocoService.translate('playoffs.bye');
+          matches.push({
+            matchNumber,
+            team1Name,
+            team2Name,
+            isBye: !team1 || !team2,
+          });
+        } else {
+          // Subsequent rounds: show "Winner of match X"
+          const winnerOf = (round: string, match: number) => {
+            const roundLabel2 = this.translocoService.translate(round);
+            return this.translocoService.translate('finale.winnerOf', {
+              round: roundLabel2,
+              match: String(match),
+            });
+          };
+          matches.push({
+            matchNumber,
+            team1Name: winnerOf(prevRoundLabel, 2 * matchNumber - 1),
+            team2Name: winnerOf(prevRoundLabel, 2 * matchNumber),
+            isBye: false,
+          });
+        }
+      }
+
+      rounds.push({ roundLabel, roundOrder: currentSize, matches });
+      prevRoundLabel = roundLabel;
+      currentSize = Math.floor(currentSize / 2);
+    }
+
+    // Sort from largest round (first round) to final
+    return rounds.sort((a, b) => b.roundOrder - a.roundOrder);
+  });
+
+  canGoNext = computed(
+    () => this.playoffsName().trim().length > 0 && this.selectedTeams().length > 0,
+  );
+
+  onAddSelectedTeam(): void {
+    const pendingTeamRefs = this.pendingTeamRef();
+    if (pendingTeamRefs.length === 0) return;
+
+    const teamsById = new Map(this.data.teams.map((team) => [team.ref.id, team.name]));
+    const selectedIds = new Set(this.selectedTeams().map((team) => team.key));
+    const teamsToAdd: KeyValue<string, string>[] = [];
+
+    for (const teamRef of pendingTeamRefs) {
+      if (selectedIds.has(teamRef)) {
+        continue;
+      }
+
+      const teamName = teamsById.get(teamRef);
+      if (!teamName) {
+        continue;
+      }
+
+      selectedIds.add(teamRef);
+      teamsToAdd.push({ key: teamRef, value: teamName });
+    }
+
+    if (teamsToAdd.length > 0) {
+      this.selectedTeams.update((teams) => [...teams, ...teamsToAdd]);
+    }
+
+    this.pendingTeamRef.set([]);
+  }
+
+  onRemoveTeam(team: KeyValue<string, string>): void {
+    this.selectedTeams.update((teams) => teams.filter((t) => t.key !== team.key));
+  }
+
+  onNext(): void {
+    if (this.canGoNext()) {
+      this.currentStep.set(2);
+    }
+  }
+
+  onBack(): void {
+    this.currentStep.set(1);
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+
+  onSave(): void {
+    const name = this.playoffsName().trim();
+    if (!name || this.selectedTeams().length === 0) return;
+    const result: SavePlayoffsEvent = {
+      serieRef: this.data.serieRef,
+      name,
+      orderedTeamRefs: this.data.teams
+        .filter((t) => this.selectedTeams().some((st) => st.key === t.ref.id))
+        .map((t) => t.ref),
+      size: this.bracketSize(),
+    };
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
@@ -8,16 +8,20 @@ import { Message } from 'primeng/message';
 import { MultiSelectModule } from 'primeng/multiselect';
 import { TooltipModule } from 'primeng/tooltip';
 import { OrderListModule } from 'primeng/orderlist';
+import { SelectButton } from 'primeng/selectbutton';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import type { Team } from '../../teams/teams';
 import { KeyValue } from '@angular/common';
+
+export type PlayoffsMatchOrganization = 'linear' | 'competition';
 
 export interface SavePlayoffsEvent {
   serieRef: DocumentReference;
   name: string;
   orderedTeamRefs: DocumentReference[];
   size: number;
+  matchOrganization: PlayoffsMatchOrganization;
 }
 
 interface PlayoffsFormDialogData {
@@ -49,6 +53,24 @@ function getRoundLabel(size: number): string {
   return `finale.rounds.${size}`;
 }
 
+function getFirstRoundPairingIndexes(
+  bracketSize: number,
+  matchOrganization: PlayoffsMatchOrganization,
+): { team1Index: number; team2Index: number }[] {
+  const matchCount = bracketSize / 2;
+  if (matchOrganization === 'competition') {
+    return Array.from({ length: matchCount }, (_, index) => ({
+      team1Index: index,
+      team2Index: bracketSize - 1 - index,
+    }));
+  }
+
+  return Array.from({ length: matchCount }, (_, index) => ({
+    team1Index: index * 2,
+    team2Index: index * 2 + 1,
+  }));
+}
+
 @Component({
   selector: 'app-playoffs-form-dialog',
   imports: [
@@ -61,6 +83,7 @@ function getRoundLabel(size: number): string {
     Message,
     TooltipModule,
     OrderListModule,
+    SelectButton,
   ],
   templateUrl: './playoffs-form-dialog.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -80,6 +103,18 @@ export class PlayoffsFormDialog {
   playoffsName = signal('');
   selectedTeams = signal<KeyValue<string, string>[]>([]);
   pendingTeamRef = signal<string[]>([]);
+  matchOrganization = signal<PlayoffsMatchOrganization>('linear');
+
+  matchOrganizationOptions = computed(() => [
+    {
+      label: this.translocoService.translate('playoffs.matchOrganization.options.linear'),
+      value: 'linear' as const,
+    },
+    {
+      label: this.translocoService.translate('playoffs.matchOrganization.options.competition'),
+      value: 'competition' as const,
+    },
+  ]);
 
   availableTeams = computed<KeyValue<string, string>[]>(() => {
     const selectedIds = new Set(this.selectedTeams().map((t) => t.key));
@@ -97,6 +132,7 @@ export class PlayoffsFormDialog {
   bracketPreview = computed((): BracketPreviewRound[] => {
     const teams = this.selectedTeams();
     const size = this.bracketSize();
+    const firstRoundPairings = getFirstRoundPairingIndexes(size, this.matchOrganization());
     const rounds: BracketPreviewRound[] = [];
 
     // Generate all rounds from first round (largest) down to final
@@ -110,9 +146,9 @@ export class PlayoffsFormDialog {
 
       for (let matchNumber = 1; matchNumber <= matchCount; matchNumber++) {
         if (prevRoundLabel === null) {
-          // First round: assign teams linearly
-          const team1Index = (matchNumber - 1) * 2;
-          const team2Index = (matchNumber - 1) * 2 + 1;
+          const pairing = firstRoundPairings[matchNumber - 1];
+          const team1Index = pairing.team1Index;
+          const team2Index = pairing.team2Index;
           const team1 = teams[team1Index];
           const team2 = teams[team2Index];
           const team1Name = team1?.value ?? this.translocoService.translate('playoffs.bye');
@@ -204,13 +240,15 @@ export class PlayoffsFormDialog {
   onSave(): void {
     const name = this.playoffsName().trim();
     if (!name || this.selectedTeams().length === 0) return;
+    const teamById = new Map(this.data.teams.map((team) => [team.ref.id, team.ref]));
     const result: SavePlayoffsEvent = {
       serieRef: this.data.serieRef,
       name,
-      orderedTeamRefs: this.data.teams
-        .filter((t) => this.selectedTeams().some((st) => st.key === t.ref.id))
-        .map((t) => t.ref),
+      orderedTeamRefs: this.selectedTeams()
+        .map((team) => teamById.get(team.key))
+        .filter((teamRef): teamRef is DocumentReference => teamRef !== undefined),
       size: this.bracketSize(),
+      matchOrganization: this.matchOrganization(),
     };
     this.dialogRef.close(result);
   }

--- a/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
+++ b/src/app/tournaments/shared/phases/playoffs-form-dialog/playoffs-form-dialog.ts
@@ -12,7 +12,7 @@ import { SelectButton } from 'primeng/selectbutton';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import type { Team } from '../../teams/teams';
-import { KeyValue } from '@angular/common';
+import { KeyValue, NgStyle } from '@angular/common';
 
 export type PlayoffsMatchOrganization = 'linear' | 'competition';
 
@@ -40,6 +40,19 @@ export interface BracketPreviewRound {
   roundLabel: string;
   roundOrder: number;
   matches: BracketPreviewMatch[];
+}
+
+export interface BracketTreeMatch {
+  data: BracketPreviewMatch;
+  slotSpan: number;
+  gridRow: number;
+}
+
+export interface BracketTreeRound {
+  roundLabel: string;
+  roundOrder: number;
+  matches: BracketTreeMatch[];
+  isFinalRound: boolean;
 }
 
 function nextPowerOf2(n: number): number {
@@ -84,8 +97,10 @@ function getFirstRoundPairingIndexes(
     TooltipModule,
     OrderListModule,
     SelectButton,
+    NgStyle,
   ],
   templateUrl: './playoffs-form-dialog.html',
+  styleUrl: './playoffs-form-dialog.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlayoffsFormDialog {
@@ -184,6 +199,39 @@ export class PlayoffsFormDialog {
 
     // Sort from largest round (first round) to final
     return rounds.sort((a, b) => b.roundOrder - a.roundOrder);
+  });
+
+  bracketTreeRounds = computed((): BracketTreeRound[] => {
+    const rounds = this.bracketPreview();
+    const finalRoundOrder = rounds[rounds.length - 1]?.roundOrder;
+
+    return rounds.map((round, roundIndex) => {
+      const slotSpan = 2 ** roundIndex;
+      // Center slot index: midpoint of the span assigned to this match
+      const matches = round.matches.map((match, matchIndex) => ({
+        data: match,
+        slotSpan,
+        // gridRow is 1-based center of the span block
+        gridRow: matchIndex * slotSpan + 1,
+      }));
+
+      return {
+        roundLabel: round.roundLabel,
+        roundOrder: round.roundOrder,
+        matches,
+        isFinalRound: round.roundOrder === finalRoundOrder,
+      };
+    });
+  });
+
+  bracketTreeStyle = computed(() => {
+    const rounds = this.bracketTreeRounds();
+    const firstRoundMatchCount = rounds[0]?.matches.length ?? 0;
+
+    return {
+      '--playoffs-tree-round-count': String(Math.max(rounds.length, 1)),
+      '--playoffs-tree-slot-count': String(firstRoundMatchCount > 0 ? firstRoundMatchCount * 2 : 2),
+    };
   });
 
   canGoNext = computed(

--- a/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.html
+++ b/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.html
@@ -20,16 +20,18 @@
     <h5 class="text-lg font-semibold mb-2">{{ 'admin.poules.teamsInPoule' | transloco }}</h5>
 
     <div class="flex gap-2 items-center mb-3">
-      <p-select
+      <p-multiselect
         class="flex-1"
         [options]="availableTeams()"
         optionLabel="name"
         optionValue="ref"
         [placeholder]="'admin.poules.selectTeam' | transloco"
+        display="chip"
         [ngModel]="pendingTeamRef()"
         (ngModelChange)="pendingTeamRef.set($event)"
         name="team-select"
         appendTo="body"
+        [filter]="true"
         [showClear]="true"
       />
       <p-button
@@ -37,7 +39,7 @@
         severity="primary"
         icon="pi pi-plus"
         [label]="'admin.poules.addTeam' | transloco"
-        [disabled]="!pendingTeamRef()"
+        [disabled]="pendingTeamRef().length === 0"
         (onClick)="onAddSelectedTeam()"
         data-testid="dialog-add-team-button"
       />

--- a/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.spec.ts
@@ -170,13 +170,16 @@ describe('PouleFormDialog (editing)', () => {
   });
 
   it('should add multiple selected teams at once', () => {
-    component.pendingTeamRef.set([teamCRef]);
+    const teamDRef = { id: 'team-d' } as DocumentReference;
+
+    component.pendingTeamRef.set([teamCRef, teamDRef]);
     component.onAddSelectedTeam();
 
     expect(component.selectedTeamRefs().map((ref) => ref.id)).toEqual([
       'team-a',
       'team-b',
       'team-c',
+      'team-d',
     ]);
     expect(component.pendingTeamRef()).toEqual([]);
   });

--- a/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.spec.ts
+++ b/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.spec.ts
@@ -158,7 +158,7 @@ describe('PouleFormDialog (editing)', () => {
   });
 
   it('should add a selected team', () => {
-    component.pendingTeamRef.set(teamCRef);
+    component.pendingTeamRef.set([teamCRef]);
     component.onAddSelectedTeam();
 
     expect(component.selectedTeamRefs().map((ref) => ref.id)).toEqual([
@@ -166,7 +166,19 @@ describe('PouleFormDialog (editing)', () => {
       'team-b',
       'team-c',
     ]);
-    expect(component.pendingTeamRef()).toBeNull();
+    expect(component.pendingTeamRef()).toEqual([]);
+  });
+
+  it('should add multiple selected teams at once', () => {
+    component.pendingTeamRef.set([teamCRef]);
+    component.onAddSelectedTeam();
+
+    expect(component.selectedTeamRefs().map((ref) => ref.id)).toEqual([
+      'team-a',
+      'team-b',
+      'team-c',
+    ]);
+    expect(component.pendingTeamRef()).toEqual([]);
   });
 
   it('should confirm and remove a selected team', () => {
@@ -184,7 +196,7 @@ describe('PouleFormDialog (editing)', () => {
   });
 
   it('should return final team refs on save', () => {
-    component.pendingTeamRef.set(teamCRef);
+    component.pendingTeamRef.set([teamCRef]);
     component.onAddSelectedTeam();
 
     component.pouleName.set('Poule edit');

--- a/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.ts
+++ b/src/app/tournaments/shared/phases/poule-form-dialog/poule-form-dialog.ts
@@ -7,7 +7,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { ConfirmationService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { Message } from 'primeng/message';
-import { Select } from 'primeng/select';
+import { MultiSelectModule } from 'primeng/multiselect';
 import { TooltipModule } from 'primeng/tooltip';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -37,7 +37,7 @@ interface PouleFormDialogData {
     InputTextModule,
     Button,
     TranslocoPipe,
-    Select,
+    MultiSelectModule,
     Message,
     ConfirmDialogModule,
     TooltipModule,
@@ -61,7 +61,7 @@ export class PouleFormDialog {
   };
 
   pouleName = signal(this.data.pouleName);
-  pendingTeamRef = signal<DocumentReference | null>(null);
+  pendingTeamRef = signal<DocumentReference[]>([]);
   selectedTeamRefs = signal<DocumentReference[]>(this.data.editingPoule?.refTeams ?? []);
 
   selectedTeams = computed(() => {
@@ -88,16 +88,16 @@ export class PouleFormDialog {
   }
 
   onAddSelectedTeam(): void {
-    const teamRef = this.pendingTeamRef();
-    if (!teamRef) return;
+    const pendingTeamRefs = this.pendingTeamRef();
+    if (pendingTeamRefs.length === 0) return;
 
-    const hasTeamAlready = this.selectedTeamRefs().some(
-      (currentRef) => currentRef.id === teamRef.id,
-    );
-    if (hasTeamAlready) return;
+    const selectedIds = new Set(this.selectedTeamRefs().map((teamRef) => teamRef.id));
+    const refsToAdd = pendingTeamRefs.filter((teamRef) => !selectedIds.has(teamRef.id));
+    if (refsToAdd.length > 0) {
+      this.selectedTeamRefs.update((teamRefs) => [...teamRefs, ...refsToAdd]);
+    }
 
-    this.selectedTeamRefs.update((teamRefs) => [...teamRefs, teamRef]);
-    this.pendingTeamRef.set(null);
+    this.pendingTeamRef.set([]);
   }
 
   onRequestRemoveTeam(teamRef: DocumentReference): void {


### PR DESCRIPTION
- Added `@angular/cdk` dependency for UI components.
- Updated English, Spanish, Basque, and French translations for playoffs.
- Implemented `generatePlayoffsForSerie` method in `FirebaseService` to create playoff matches.
- Created `PlayoffsFormDialog` component for user input on playoffs setup.
- Integrated playoffs generation into `TournamentActionsService`.
- Updated phases handling in `Phases` class to include playoffs dialog.
- Enhanced team selection in `PouleFormDialog` to support multiple selections.
- Added tests for the new playoffs functionality and UI components.