### PR TITLE
Add FAQ and GitHub-backed contact pages

### DIFF
--- a/functions/src/create-contact-issue.ts
+++ b/functions/src/create-contact-issue.ts
@@ -1,6 +1,9 @@
+import { createHash } from 'node:crypto';
 import { logger } from 'firebase-functions';
 import { defineSecret } from 'firebase-functions/params';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 
 const githubContactToken = defineSecret('GITHUB_CONTACT_TOKEN');
 const GITHUB_API_URL = 'https://api.github.com';
@@ -9,6 +12,12 @@ const GITHUB_REPO = 'txapelketak';
 const GITHUB_CONTACT_LABEL = 'contact';
 const ALLOWED_LOCALES = new Set(['fr', 'eu', 'en', 'es']);
 const GITHUB_USERNAME_PATTERN = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+const CONTACT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const CONTACT_RATE_LIMIT_MAX_REQUESTS = 3;
+
+if (getApps().length === 0) {
+  initializeApp();
+}
 
 interface CreateContactIssueData {
   name: string;
@@ -82,6 +91,49 @@ function normalizeLocale(value: unknown): string {
   return ALLOWED_LOCALES.has(value) ? value : 'fr';
 }
 
+function buildRateLimitKey(ip: string, userAgent: string): string {
+  return createHash('sha256').update(`${ip}|${userAgent}`).digest('hex');
+}
+
+async function enforceRateLimit(ip: string, userAgent: string): Promise<void> {
+  const db = getFirestore();
+  const key = buildRateLimitKey(ip, userAgent);
+  const rateLimitRef = db.collection('contactRateLimits').doc(key);
+  const now = Date.now();
+
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(rateLimitRef);
+    const data = snapshot.data() as
+      | {
+          windowStartedAt?: number;
+          requestCount?: number;
+        }
+      | undefined;
+
+    const windowStartedAt = data?.windowStartedAt ?? now;
+    const requestCount = data?.requestCount ?? 0;
+    const sameWindow = now - windowStartedAt < CONTACT_RATE_LIMIT_WINDOW_MS;
+    const nextCount = sameWindow ? requestCount + 1 : 1;
+
+    if (sameWindow && requestCount >= CONTACT_RATE_LIMIT_MAX_REQUESTS) {
+      throw new HttpsError(
+        'resource-exhausted',
+        'Too many contact requests from the same client. Please try again later.',
+      );
+    }
+
+    transaction.set(
+      rateLimitRef,
+      {
+        windowStartedAt: sameWindow ? windowStartedAt : now,
+        requestCount: nextCount,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+  });
+}
+
 function buildIssueBody(payload: {
   name: string;
   githubUsername?: string;
@@ -133,7 +185,13 @@ export const createContactIssue = onCall<CreateContactIssueData>(
     });
     const githubUsername = normalizeGithubUsername(request.data?.githubUsername);
     const locale = normalizeLocale(request.data?.locale);
-    const userAgent = request.rawRequest.get('user-agent') ?? '';
+    const userAgent = request.rawRequest.get('user-agent') ?? 'unknown';
+    const clientIp =
+      request.rawRequest.ip ||
+      request.rawRequest.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      'unknown';
+
+    await enforceRateLimit(clientIp, userAgent);
 
     let token: string;
     try {

--- a/functions/src/create-contact-issue.ts
+++ b/functions/src/create-contact-issue.ts
@@ -1,0 +1,220 @@
+import { logger } from 'firebase-functions';
+import { defineSecret } from 'firebase-functions/params';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+
+const githubContactToken = defineSecret('GITHUB_CONTACT_TOKEN');
+const GITHUB_API_URL = 'https://api.github.com';
+const GITHUB_OWNER = 'bastienmoulia';
+const GITHUB_REPO = 'txapelketak';
+const GITHUB_CONTACT_LABEL = 'contact';
+const ALLOWED_LOCALES = new Set(['fr', 'eu', 'en', 'es']);
+const GITHUB_USERNAME_PATTERN = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+
+interface CreateContactIssueData {
+  name: string;
+  githubUsername?: string;
+  subject: string;
+  message: string;
+  locale?: string;
+  website?: string;
+}
+
+interface CreateContactIssueResponse {
+  issueNumber: number;
+  issueUrl: string;
+}
+
+function requireText(
+  value: unknown,
+  fieldName: string,
+  options: { minLength: number; maxLength: number },
+): string {
+  if (typeof value !== 'string') {
+    throw new HttpsError('invalid-argument', `${fieldName} must be a string`);
+  }
+
+  const normalized = value.trim().replace(/\r\n/g, '\n');
+
+  if (normalized.length < options.minLength) {
+    throw new HttpsError(
+      'invalid-argument',
+      `${fieldName} must contain at least ${options.minLength} characters`,
+    );
+  }
+
+  if (normalized.length > options.maxLength) {
+    throw new HttpsError(
+      'invalid-argument',
+      `${fieldName} must contain at most ${options.maxLength} characters`,
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeGithubUsername(value: unknown): string | undefined {
+  if (value == null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new HttpsError('invalid-argument', 'githubUsername must be a string');
+  }
+
+  const normalized = value.trim().replace(/^@/, '');
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  if (!GITHUB_USERNAME_PATTERN.test(normalized)) {
+    throw new HttpsError('invalid-argument', 'githubUsername is invalid');
+  }
+
+  return normalized;
+}
+
+function normalizeLocale(value: unknown): string {
+  if (typeof value !== 'string') {
+    return 'fr';
+  }
+
+  return ALLOWED_LOCALES.has(value) ? value : 'fr';
+}
+
+function buildIssueBody(payload: {
+  name: string;
+  githubUsername?: string;
+  subject: string;
+  message: string;
+  locale: string;
+  userAgent: string;
+}): string {
+  return [
+    '## Contact request',
+    '',
+    `- Name: ${payload.name}`,
+    `- GitHub username: ${payload.githubUsername ? `@${payload.githubUsername}` : 'N/A'}`,
+    `- Locale: ${payload.locale}`,
+    '- Source: public contact form',
+    '',
+    '## Subject',
+    '',
+    payload.subject,
+    '',
+    '## Message',
+    '',
+    payload.message,
+    '',
+    '---',
+    '',
+    `User-Agent: ${payload.userAgent || 'unknown'}`,
+  ].join('\n');
+}
+
+export const createContactIssue = onCall<CreateContactIssueData>(
+  {
+    region: 'europe-west1',
+    secrets: [githubContactToken],
+  },
+  async (request): Promise<CreateContactIssueResponse> => {
+    if (typeof request.data?.website === 'string' && request.data.website.trim().length > 0) {
+      throw new HttpsError('permission-denied', 'Contact submission rejected');
+    }
+
+    const name = requireText(request.data?.name, 'name', { minLength: 2, maxLength: 80 });
+    const subject = requireText(request.data?.subject, 'subject', {
+      minLength: 3,
+      maxLength: 120,
+    }).replace(/\s+/g, ' ');
+    const message = requireText(request.data?.message, 'message', {
+      minLength: 10,
+      maxLength: 5000,
+    });
+    const githubUsername = normalizeGithubUsername(request.data?.githubUsername);
+    const locale = normalizeLocale(request.data?.locale);
+    const userAgent = request.rawRequest.get('user-agent') ?? '';
+
+    let token: string;
+    try {
+      token = githubContactToken.value();
+    } catch (error) {
+      logger.error('GITHUB_CONTACT_TOKEN is not configured', error);
+      throw new HttpsError(
+        'failed-precondition',
+        'GITHUB_CONTACT_TOKEN is not configured in Firebase Functions',
+      );
+    }
+
+    const response = await fetch(`${GITHUB_API_URL}/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'txapelketak-contact-function',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: JSON.stringify({
+        title: `[Contact] ${subject}`,
+        labels: [GITHUB_CONTACT_LABEL],
+        body: buildIssueBody({
+          name,
+          githubUsername,
+          subject,
+          message,
+          locale,
+          userAgent,
+        }),
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      let githubMessage: string | undefined;
+      try {
+        const parsed = JSON.parse(errorBody) as { message?: string };
+        githubMessage = typeof parsed.message === 'string' ? parsed.message : undefined;
+      } catch {
+        githubMessage = undefined;
+      }
+
+      logger.error('GitHub issue creation failed', {
+        status: response.status,
+        body: errorBody,
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        throw new HttpsError(
+          'failed-precondition',
+          githubMessage
+            ? `GitHub rejected GITHUB_CONTACT_TOKEN: ${githubMessage}`
+            : 'GitHub rejected GITHUB_CONTACT_TOKEN. Check the token and its Issues permission.',
+        );
+      }
+
+      if (response.status === 422) {
+        throw new HttpsError(
+          'invalid-argument',
+          githubMessage || 'GitHub refused the contact issue payload',
+        );
+      }
+
+      throw new HttpsError(
+        'internal',
+        githubMessage ? `GitHub error: ${githubMessage}` : 'Unable to create the contact ticket',
+      );
+    }
+
+    const issue = (await response.json()) as { number?: number; html_url?: string };
+
+    if (typeof issue.number !== 'number' || typeof issue.html_url !== 'string') {
+      throw new HttpsError('internal', 'GitHub returned an invalid contact ticket response');
+    }
+
+    return {
+      issueNumber: issue.number,
+      issueUrl: issue.html_url,
+    };
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,3 +1,4 @@
 export { deleteTournament } from './delete-tournament.js';
 export { exportCalendar } from './export-calendar.js';
 export { aiTimeSlots } from './ai-time-slots.js';
+export { createContactIssue } from './create-contact-issue.js';

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -4,6 +4,8 @@
   },
   "routes": {
     "home": "Home",
+    "faq": "FAQ",
+    "contact": "Contact",
     "tournaments": "Tournaments",
     "tournamentNew": "Create a tournament",
     "tournamentDetail": "Tournament details",
@@ -54,9 +56,94 @@
         "description": "Open source code, no ads, no limitations. Play away."
       }
     },
+    "help": {
+      "title": "Need help?",
+      "description": "Browse the frequently asked questions or open a public GitHub ticket from the contact page.",
+      "faq": {
+        "title": "Read the FAQ",
+        "description": "Learn how tournament formats, live scores, exports, and link-based access work.",
+        "action": "Open the FAQ"
+      },
+      "contact": {
+        "title": "Contact the project",
+        "description": "Send a request, report a bug, or share an idea with a form that creates a GitHub ticket.",
+        "action": "Open contact"
+      }
+    },
     "tournaments": {
       "title": "Tournaments",
       "seeAll": "See all tournaments"
+    }
+  },
+  "faq": {
+    "eyebrow": "Help",
+    "title": "FAQ",
+    "intro": "The answers below are based on the features already available in Txapelketak for organizers and visitors.",
+    "actions": {
+      "contact": "Contact the project",
+      "home": "Back to home"
+    },
+    "items": {
+      "overview": {
+        "question": "What is Txapelketak for?",
+        "answer": "Txapelketak helps you create a tournament, manage players or teams, schedule matches, and publish live scores and rankings."
+      },
+      "formats": {
+        "question": "Which tournament formats are supported?",
+        "answer": "The app supports round-robin groups, knockout brackets, and mixed formats combining groups with a final phase."
+      },
+      "live": {
+        "question": "Are scores and rankings updated live?",
+        "answer": "Yes. Results entered in the admin interface immediately update matches, statistics, and the public rankings."
+      },
+      "roles": {
+        "question": "How does organizer access work?",
+        "answer": "Administration uses token-based links. Admin and organizer roles can manage a tournament without a traditional user account."
+      },
+      "calendar": {
+        "question": "Can I export the match calendar?",
+        "answer": "Yes. The app can generate an .ics calendar to download or subscribe to tournament or team matches."
+      },
+      "yaml": {
+        "question": "Can I back up or restore a tournament?",
+        "answer": "Yes. Tournament data can be exported and imported as YAML to simplify backups and migrations."
+      },
+      "languages": {
+        "question": "Is the app multilingual and open source?",
+        "answer": "Yes. The interface is designed for French, Basque, English, and Spanish, and the project is open source."
+      }
+    }
+  },
+  "contact": {
+    "eyebrow": "Support",
+    "title": "Contact",
+    "intro": "Use this form to report a bug, ask a question, or suggest an improvement.",
+    "publicNotice": "This form creates a public GitHub issue. Do not share private or sensitive information here.",
+    "success": "GitHub ticket #{{issueNumber}} was created successfully.",
+    "form": {
+      "name": "Name or nickname *",
+      "githubUsername": "GitHub username (optional)",
+      "githubUsernameHelp": "Add your GitHub username if you want a public follow-up directly on the ticket.",
+      "subject": "Subject *",
+      "message": "Message *",
+      "website": "Website",
+      "reset": "Reset",
+      "submit": "Create ticket",
+      "submitError": "The ticket could not be created right now.",
+      "submitUnavailable": "The contact service is unavailable. Check that the Functions emulator or Firebase backend is running.",
+      "errors": {
+        "required": "This field is required.",
+        "minLength": "This field must contain at least {{count}} characters.",
+        "maxLength": "This field must contain at most {{count}} characters.",
+        "githubUsername": "The GitHub username is invalid.",
+        "invalid": "The entered value is invalid."
+      }
+    },
+    "sidebar": {
+      "title": "Before sending",
+      "description": "Check the FAQ first: your answer may already be there.",
+      "faq": "View FAQ",
+      "viewIssue": "View created ticket"
     }
   },
   "tournaments": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -4,8 +4,10 @@
   },
   "routes": {
     "home": "Inicio",
+    "faq": "FAQ",
+    "contact": "Contacto",
     "tournaments": "Torneos",
-    "tournamentNew": "Crear un torneo",
+    "tournamentNew": "Crear torneo",
     "tournamentDetail": "Detalle del torneo",
     "admin": "Administración"
   },
@@ -54,9 +56,94 @@
         "description": "Código abierto, sin publicidad, sin limitaciones. ¡A jugar!"
       }
     },
+    "help": {
+      "title": "¿Necesitas ayuda?",
+      "description": "Consulta las preguntas frecuentes o abre un ticket público de GitHub desde la página de contacto.",
+      "faq": {
+        "title": "Consultar la FAQ",
+        "description": "Descubre cómo funcionan los formatos de torneo, los marcadores en directo, las exportaciones y el acceso por enlace.",
+        "action": "Abrir la FAQ"
+      },
+      "contact": {
+        "title": "Contactar con el proyecto",
+        "description": "Envía una solicitud, informa de un error o comparte una idea con un formulario que crea un ticket en GitHub.",
+        "action": "Abrir contacto"
+      }
+    },
     "tournaments": {
       "title": "Torneos",
       "seeAll": "Ver todos los torneos"
+    }
+  },
+  "faq": {
+    "eyebrow": "Ayuda",
+    "title": "FAQ",
+    "intro": "Las respuestas siguientes se basan en las funciones ya disponibles en Txapelketak para organizadores y visitantes.",
+    "actions": {
+      "contact": "Contactar con el proyecto",
+      "home": "Volver al inicio"
+    },
+    "items": {
+      "overview": {
+        "question": "¿Para qué sirve Txapelketak?",
+        "answer": "Txapelketak permite crear un torneo, gestionar jugadores o equipos, planificar partidos y publicar marcadores y clasificaciones en directo."
+      },
+      "formats": {
+        "question": "¿Qué formatos de torneo se pueden gestionar?",
+        "answer": "La aplicación gestiona liguillas por grupos, cuadros eliminatorios y formatos mixtos que combinan grupos con fase final."
+      },
+      "live": {
+        "question": "¿Los marcadores y las clasificaciones se actualizan en directo?",
+        "answer": "Sí. Los resultados introducidos en la interfaz de administración actualizan de inmediato los partidos, las estadísticas y la clasificación pública."
+      },
+      "roles": {
+        "question": "¿Cómo funciona el acceso de organizador?",
+        "answer": "La administración usa enlaces con token. Los roles admin y organizador pueden gestionar el torneo sin una cuenta de usuario clásica."
+      },
+      "calendar": {
+        "question": "¿Se puede exportar el calendario de partidos?",
+        "answer": "Sí. La aplicación puede generar un calendario .ics para descargarlo o suscribirse a los partidos de un torneo o de un equipo."
+      },
+      "yaml": {
+        "question": "¿Se puede guardar o restaurar un torneo?",
+        "answer": "Sí. Los datos del torneo pueden exportarse e importarse en YAML para facilitar copias de seguridad y migraciones."
+      },
+      "languages": {
+        "question": "¿La aplicación es multilingüe y open source?",
+        "answer": "Sí. La interfaz está pensada para francés, euskera, inglés y español, y el proyecto es open source."
+      }
+    }
+  },
+  "contact": {
+    "eyebrow": "Soporte",
+    "title": "Contacto",
+    "intro": "Usa este formulario para informar de un error, hacer una pregunta o proponer una mejora.",
+    "publicNotice": "Este formulario crea una issue pública en GitHub. No compartas información privada o sensible aquí.",
+    "success": "La issue de GitHub #{{issueNumber}} se ha creado correctamente.",
+    "form": {
+      "name": "Nombre o apodo *",
+      "githubUsername": "Nombre de usuario de GitHub (opcional)",
+      "githubUsernameHelp": "Añade tu nombre de usuario de GitHub si quieres recibir una respuesta pública directamente en la issue.",
+      "subject": "Asunto *",
+      "message": "Mensaje *",
+      "website": "Sitio web",
+      "reset": "Restablecer",
+      "submit": "Crear ticket",
+      "submitError": "No se ha podido crear el ticket por ahora.",
+      "submitUnavailable": "El servicio de contacto no está disponible. Comprueba que el emulador de Functions o el backend de Firebase esté iniciado.",
+      "errors": {
+        "required": "Este campo es obligatorio.",
+        "minLength": "Este campo debe contener al menos {{count}} caracteres.",
+        "maxLength": "Este campo debe contener como máximo {{count}} caracteres.",
+        "githubUsername": "El nombre de usuario de GitHub no es válido.",
+        "invalid": "El valor introducido no es válido."
+      }
+    },
+    "sidebar": {
+      "title": "Antes de enviar",
+      "description": "Consulta primero la FAQ: puede que la respuesta ya esté disponible.",
+      "faq": "Ver la FAQ",
+      "viewIssue": "Ver la issue creada"
     }
   },
   "tournaments": {

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -4,9 +4,11 @@
   },
   "routes": {
     "home": "Hasiera",
+    "faq": "FAQ",
+    "contact": "Kontaktua",
     "tournaments": "Txapelketak",
     "tournamentNew": "Txapelketa sortu",
-    "tournamentDetail": "Txapelketaren xehetasunak",
+    "tournamentDetail": "Txapelketaren xehetasuna",
     "admin": "Administrazioa"
   },
   "header": {
@@ -54,9 +56,94 @@
         "description": "Kode irekia, iragarkiik gabe, mugarik gabe. Jolastu!"
       }
     },
+    "help": {
+      "title": "Laguntza behar duzu?",
+      "description": "Ikusi ohiko galderak edo ireki GitHub ticket publiko bat kontaktu orritik.",
+      "faq": {
+        "title": "FAQ kontsultatu",
+        "description": "Ikasi nola funtzionatzen duten txapelketa formatuek, zuzeneko markagailuek, esportazioek eta esteka bidezko sarbideak.",
+        "action": "FAQ ireki"
+      },
+      "contact": {
+        "title": "Proiektuarekin harremanetan jarri",
+        "description": "Bidali eskaera bat, akats bat edo hobekuntza ideia bat GitHub ticket bat sortzen duen formulario baten bidez.",
+        "action": "Kontaktua ireki"
+      }
+    },
     "tournaments": {
       "title": "Txapelketak",
       "seeAll": "Ikusi txapelketa guztiak"
+    }
+  },
+  "faq": {
+    "eyebrow": "Laguntza",
+    "title": "FAQ",
+    "intro": "Beheko erantzunek Txapelketak aplikazioan dagoeneko erabilgarri dauden funtzioak azaltzen dituzte antolatzaile eta bisitarientzat.",
+    "actions": {
+      "contact": "Proiektuarekin harremanetan jarri",
+      "home": "Hasierara itzuli"
+    },
+    "items": {
+      "overview": {
+        "question": "Zertarako da Txapelketak?",
+        "answer": "Txapelketak txapelketa bat sortzeko, jokalariak edo taldeak kudeatzeko, partidak antolatzeko eta markagailuak eta sailkapenak zuzenean argitaratzeko erabiltzen da."
+      },
+      "formats": {
+        "question": "Zein txapelketa formatu onartzen dira?",
+        "answer": "Aplikazioak multzoak, kanporaketa zuzeneko final faseak eta multzoak + final fasea uztartzen dituzten formatu mistoak kudeatzen ditu."
+      },
+      "live": {
+        "question": "Markagailuak eta sailkapenak zuzenean eguneratzen al dira?",
+        "answer": "Bai. Administrazio interfazean sartzen diren emaitzek berehala eguneratzen dituzte partidak, estatistikak eta ikusgai dagoen sailkapena."
+      },
+      "roles": {
+        "question": "Nola dabil antolatzailearen sarbidea?",
+        "answer": "Administrazioa token bidezko estekekin egiten da. Admin eta antolatzaile rolek txapelketa kudea dezakete ohiko erabiltzaile konturik gabe."
+      },
+      "calendar": {
+        "question": "Partiden egutegia esporta daiteke?",
+        "answer": "Bai. Aplikazioak .ics egutegi bat sor dezake txapelketa edo talde baten partidak deskargatzeko edo harpidetzeko."
+      },
+      "yaml": {
+        "question": "Txapelketa bat gorde edo leheneratu daiteke?",
+        "answer": "Bai. Txapelketako datuak YAML formatuan esportatu eta inportatu daitezke babeskopiak eta migrazioak errazteko."
+      },
+      "languages": {
+        "question": "Aplikazioa eleanitza eta open source al da?",
+        "answer": "Bai. Interfazea frantsesez, euskaraz, ingelesez eta gaztelaniaz prestatuta dago, eta proiektua open source da."
+      }
+    }
+  },
+  "contact": {
+    "eyebrow": "Laguntza",
+    "title": "Kontaktua",
+    "intro": "Erabili formulario hau akats bat jakinarazteko, galdera bat egiteko edo hobekuntza bat proposatzeko.",
+    "publicNotice": "Formulario honek GitHub issue publiko bat sortzen du. Ez partekatu informazio pribatu edo sentikorrik hemen.",
+    "success": "GitHub-eko #{{issueNumber}} ticketa ondo sortu da.",
+    "form": {
+      "name": "Izena edo ezizena *",
+      "githubUsername": "GitHub erabiltzaile izena (aukerakoa)",
+      "githubUsernameHelp": "Gehitu zure GitHub erabiltzaile izena ticket-ean erantzun publiko bat jaso nahi baduzu.",
+      "subject": "Gaia *",
+      "message": "Mezua *",
+      "website": "Webgunea",
+      "reset": "Berrezarri",
+      "submit": "Ticketa sortu",
+      "submitError": "Ezin izan da ticketa une honetan sortu.",
+      "submitUnavailable": "Kontakturako zerbitzua ez dago erabilgarri. Egiaztatu Functions emuladorea edo Firebase backend-a martxan dagoela.",
+      "errors": {
+        "required": "Eremu hau derrigorrezkoa da.",
+        "minLength": "Eremu honek gutxienez {{count}} karaktere izan behar ditu.",
+        "maxLength": "Eremu honek gehienez {{count}} karaktere izan behar ditu.",
+        "githubUsername": "GitHub erabiltzaile izena ez da baliozkoa.",
+        "invalid": "Sartutako balioa ez da baliozkoa."
+      }
+    },
+    "sidebar": {
+      "title": "Bidali aurretik",
+      "description": "Begiratu lehenik FAQ-a: agian zure erantzuna bertan dago jada.",
+      "faq": "FAQ ikusi",
+      "viewIssue": "Sortutako issue-a ikusi"
     }
   },
   "tournaments": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -4,6 +4,8 @@
   },
   "routes": {
     "home": "Accueil",
+    "faq": "FAQ",
+    "contact": "Contact",
     "tournaments": "Tournois",
     "tournamentNew": "Créer un tournoi",
     "tournamentDetail": "Détail du tournoi",
@@ -54,9 +56,94 @@
         "description": "Code source ouvert, aucune publicité, aucune limitation. À vous de jouer."
       }
     },
+    "help": {
+      "title": "Besoin d'aide ?",
+      "description": "Retrouvez les réponses aux questions fréquentes ou ouvrez un ticket GitHub public depuis la page de contact.",
+      "faq": {
+        "title": "Consulter la FAQ",
+        "description": "Découvrez comment fonctionnent les formats de tournoi, les scores en direct, les exports et l'accès par lien.",
+        "action": "Ouvrir la FAQ"
+      },
+      "contact": {
+        "title": "Contacter le projet",
+        "description": "Envoyez une demande, un bug ou une idée d'amélioration avec un formulaire qui crée un ticket GitHub.",
+        "action": "Ouvrir le contact"
+      }
+    },
     "tournaments": {
       "title": "Tournois",
       "seeAll": "Voir tous les tournois"
+    }
+  },
+  "faq": {
+    "eyebrow": "Aide",
+    "title": "FAQ",
+    "intro": "Les réponses ci-dessous reprennent les fonctionnalités déjà disponibles dans Txapelketak pour aider les organisateurs et les visiteurs.",
+    "actions": {
+      "contact": "Contacter le projet",
+      "home": "Retour à l'accueil"
+    },
+    "items": {
+      "overview": {
+        "question": "À quoi sert Txapelketak ?",
+        "answer": "Txapelketak permet de créer un tournoi, gérer les joueurs ou équipes, planifier les parties et publier les scores et classements en temps réel."
+      },
+      "formats": {
+        "question": "Quels formats de tournoi sont gérés ?",
+        "answer": "L'application gère les tournois en poules, les phases finales à élimination directe, ainsi que les formats mixtes poules + phase finale."
+      },
+      "live": {
+        "question": "Les scores et classements sont-ils mis à jour en direct ?",
+        "answer": "Oui. Les résultats saisis dans l'interface d'administration mettent à jour les parties, les statistiques et les classements visibles publiquement."
+      },
+      "roles": {
+        "question": "Comment fonctionne l'accès organisateur ?",
+        "answer": "L'administration passe par des liens à jeton. Les rôles admin et organisateur peuvent gérer le tournoi sans compte utilisateur classique."
+      },
+      "calendar": {
+        "question": "Peut-on exporter le calendrier des parties ?",
+        "answer": "Oui. L'application peut générer un calendrier .ics pour télécharger ou s'abonner aux parties d'un tournoi ou d'une équipe."
+      },
+      "yaml": {
+        "question": "Peut-on sauvegarder ou restaurer un tournoi ?",
+        "answer": "Oui. Les données de tournoi peuvent être exportées et réimportées au format YAML pour faciliter les sauvegardes et migrations."
+      },
+      "languages": {
+        "question": "L'application est-elle multilingue et open source ?",
+        "answer": "Oui. L'interface est prévue pour le français, le basque, l'anglais et l'espagnol, et le projet est open source."
+      }
+    }
+  },
+  "contact": {
+    "eyebrow": "Support",
+    "title": "Contact",
+    "intro": "Utilisez ce formulaire pour signaler un bug, poser une question ou proposer une amélioration.",
+    "publicNotice": "Ce formulaire crée une issue GitHub publique. N'y partagez pas d'information privée ou sensible.",
+    "success": "Le ticket GitHub #{{issueNumber}} a bien été créé.",
+    "form": {
+      "name": "Nom ou pseudo *",
+      "githubUsername": "Nom d'utilisateur GitHub (optionnel)",
+      "githubUsernameHelp": "Ajoutez votre nom d'utilisateur GitHub si vous souhaitez être recontacté publiquement sur le ticket.",
+      "subject": "Sujet *",
+      "message": "Message *",
+      "website": "Site web",
+      "reset": "Réinitialiser",
+      "submit": "Créer le ticket",
+      "submitError": "Le ticket n'a pas pu être créé pour le moment.",
+      "submitUnavailable": "Le service de contact est indisponible. Vérifiez que l'émulateur Functions ou le backend Firebase est bien démarré.",
+      "errors": {
+        "required": "Ce champ est obligatoire.",
+        "minLength": "Ce champ doit contenir au moins {{count}} caractères.",
+        "maxLength": "Ce champ doit contenir au plus {{count}} caractères.",
+        "githubUsername": "Le nom d'utilisateur GitHub n'est pas valide.",
+        "invalid": "La valeur saisie n'est pas valide."
+      }
+    },
+    "sidebar": {
+      "title": "Avant d'envoyer",
+      "description": "Consultez d'abord la FAQ : la réponse à votre question s'y trouve peut-être déjà.",
+      "faq": "Voir la FAQ",
+      "viewIssue": "Voir le ticket créé"
     }
   },
   "tournaments": {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,6 +30,16 @@ export const routes: Routes = [
     loadComponent: () => import('./home/home').then((m) => m.Home),
   },
   {
+    path: 'faq',
+    title: 'routes.faq',
+    loadComponent: () => import('./faq/faq').then((m) => m.Faq),
+  },
+  {
+    path: 'contact',
+    title: 'routes.contact',
+    loadComponent: () => import('./contact/contact').then((m) => m.Contact),
+  },
+  {
     path: 'tournaments',
     loadComponent: () => import('./main/main').then((m) => m.Main),
     children: [

--- a/src/app/contact/contact.css
+++ b/src/app/contact/contact.css
@@ -1,0 +1,7 @@
+.contact-honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/src/app/contact/contact.html
+++ b/src/app/contact/contact.html
@@ -1,0 +1,173 @@
+<app-header />
+
+<main class="max-w-[960px] mx-auto px-4 py-8 flex flex-col gap-8">
+  <section
+    class="rounded-[var(--p-border-radius-xl)] bg-[var(--p-surface-card)] p-6 shadow-[var(--p-card-shadow)]"
+  >
+    <div class="flex flex-col gap-4">
+      <p class="m-0 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--p-primary-color)]">
+        {{ 'contact.eyebrow' | transloco }}
+      </p>
+      <h1 class="m-0 text-[2rem] font-bold">{{ 'contact.title' | transloco }}</h1>
+      <p class="m-0 text-[var(--p-text-muted-color)] text-lg">
+        {{ 'contact.intro' | transloco }}
+      </p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+    <div
+      class="rounded-[var(--p-border-radius-xl)] bg-[var(--p-surface-card)] p-6 shadow-[var(--p-card-shadow)]"
+    >
+      <div class="flex flex-col gap-5">
+        <p-message severity="warn">
+          {{ 'contact.publicNotice' | transloco }}
+        </p-message>
+
+        @if (createdIssue(); as issue) {
+          <p-message severity="success">
+            {{ 'contact.success' | transloco: { issueNumber: issue.issueNumber } }}
+          </p-message>
+        }
+
+        @if (submitError()) {
+          <p-message severity="error">{{ submitError() }}</p-message>
+        }
+
+        <form [formRoot]="contactForm" (submit)="onSubmit()" class="flex flex-col gap-5">
+          <div class="flex flex-col gap-2">
+            <p-floatlabel variant="on">
+              <input
+                pInputText
+                id="contact-name"
+                class="w-full"
+                [formField]="contactForm.name"
+                data-testid="contact-name"
+              />
+              <label for="contact-name">{{ 'contact.form.name' | transloco }}</label>
+            </p-floatlabel>
+            @if (showFieldError(contactForm.name)) {
+              <p-message severity="error" class="field-error">
+                {{ fieldErrorMessage(contactForm.name) }}
+              </p-message>
+            }
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <p-floatlabel variant="on">
+              <input
+                pInputText
+                id="contact-github-username"
+                class="w-full"
+                [formField]="contactForm.githubUsername"
+                data-testid="contact-github-username"
+              />
+              <label for="contact-github-username">{{
+                'contact.form.githubUsername' | transloco
+              }}</label>
+            </p-floatlabel>
+            <small class="text-[var(--p-text-muted-color)]">
+              {{ 'contact.form.githubUsernameHelp' | transloco }}
+            </small>
+            @if (showFieldError(contactForm.githubUsername)) {
+              <p-message severity="error" class="field-error">
+                {{ fieldErrorMessage(contactForm.githubUsername) }}
+              </p-message>
+            }
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <p-floatlabel variant="on">
+              <input
+                pInputText
+                id="contact-subject"
+                class="w-full"
+                [formField]="contactForm.subject"
+                data-testid="contact-subject"
+              />
+              <label for="contact-subject">{{ 'contact.form.subject' | transloco }}</label>
+            </p-floatlabel>
+            @if (showFieldError(contactForm.subject)) {
+              <p-message severity="error" class="field-error">
+                {{ fieldErrorMessage(contactForm.subject) }}
+              </p-message>
+            }
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <p-floatlabel variant="on">
+              <textarea
+                id="contact-message"
+                rows="10"
+                class="w-full p-3 rounded-[var(--p-border-radius-md)] border border-[var(--p-surface-border)] bg-[var(--p-surface-card)] text-[var(--p-text-color)]"
+                [formField]="contactForm.message"
+                data-testid="contact-message"
+              ></textarea>
+              <label for="contact-message">{{ 'contact.form.message' | transloco }}</label>
+            </p-floatlabel>
+            @if (showFieldError(contactForm.message)) {
+              <p-message severity="error" class="field-error">
+                {{ fieldErrorMessage(contactForm.message) }}
+              </p-message>
+            }
+          </div>
+
+          <div class="contact-honeypot" aria-hidden="true">
+            <label for="contact-website">{{ 'contact.form.website' | transloco }}</label>
+            <input
+              id="contact-website"
+              type="text"
+              tabindex="-1"
+              autocomplete="off"
+              [formField]="contactForm.website"
+            />
+          </div>
+
+          <div class="flex flex-wrap gap-3 justify-end">
+            <p-button
+              type="button"
+              [label]="'contact.form.reset' | transloco"
+              severity="secondary"
+              [outlined]="true"
+              (onClick)="onReset()"
+            />
+            <p-button
+              type="submit"
+              [label]="'contact.form.submit' | transloco"
+              [loading]="isSubmitting()"
+            />
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <aside
+      class="rounded-[var(--p-border-radius-xl)] bg-[var(--p-surface-card)] p-6 shadow-[var(--p-card-shadow)] h-fit"
+    >
+      <div class="flex flex-col gap-4">
+        <h2 class="m-0 text-xl font-semibold">{{ 'contact.sidebar.title' | transloco }}</h2>
+        <p class="m-0 text-[var(--p-text-muted-color)]">
+          {{ 'contact.sidebar.description' | transloco }}
+        </p>
+        <div class="flex flex-col gap-3">
+          <p-button
+            [label]="'contact.sidebar.faq' | transloco"
+            severity="secondary"
+            [outlined]="true"
+            routerLink="/faq"
+          />
+          @if (createdIssue(); as issue) {
+            <a
+              class="text-[var(--p-primary-color)] font-medium no-underline hover:underline focus:underline"
+              [href]="issue.issueUrl"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {{ 'contact.sidebar.viewIssue' | transloco }}
+            </a>
+          }
+        </div>
+      </div>
+    </aside>
+  </section>
+</main>

--- a/src/app/contact/contact.spec.ts
+++ b/src/app/contact/contact.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { providePrimeNG } from 'primeng/config';
+import { vi } from 'vitest';
+import { provideTranslocoTesting } from '../testing/transloco-testing.providers';
+import { Contact } from './contact';
+import { FirebaseService } from '../shared/services/firebase.service';
+
+describe('Contact', () => {
+  let component: Contact;
+  let fixture: ComponentFixture<Contact>;
+  let firebaseService: Pick<FirebaseService, 'createContactIssue'>;
+
+  beforeEach(async () => {
+    firebaseService = {
+      createContactIssue: vi.fn().mockResolvedValue({
+        issueNumber: 42,
+        issueUrl: 'https://github.com/bastienmoulia/txapelketak/issues/42',
+      }),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [Contact],
+      providers: [
+        provideRouter([]),
+        providePrimeNG({}),
+        ...provideTranslocoTesting(),
+        { provide: FirebaseService, useValue: firebaseService as FirebaseService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Contact);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not submit an invalid form', async () => {
+    await component.onSubmit();
+
+    expect(firebaseService.createContactIssue).not.toHaveBeenCalled();
+    expect(component.showFieldError(component.contactForm.name)).toBe(true);
+  });
+
+  it('should submit a valid signal form', async () => {
+    component.contactForm.name().value.set('Alice');
+    component.contactForm.githubUsername().value.set('alice-dev');
+    component.contactForm.subject().value.set('Besoin d’aide');
+    component.contactForm.message().value.set('Bonjour, je voudrais comprendre l’export YAML.');
+
+    await component.onSubmit();
+
+    expect(firebaseService.createContactIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Alice',
+        githubUsername: 'alice-dev',
+        subject: 'Besoin d’aide',
+      }),
+    );
+    expect(component.createdIssue()?.issueNumber).toBe(42);
+  });
+
+  it('should expose a useful backend error message', async () => {
+    firebaseService.createContactIssue = vi
+      .fn()
+      .mockRejectedValue(new Error('GITHUB_CONTACT_TOKEN is not configured in Firebase Functions'));
+
+    component.contactForm.name().value.set('Alice');
+    component.contactForm.subject().value.set('Besoin d’aide');
+    component.contactForm.message().value.set('Bonjour, je voudrais comprendre l’export YAML.');
+
+    await component.onSubmit();
+
+    expect(component.submitError()).toContain('GITHUB_CONTACT_TOKEN is not configured');
+  });
+});

--- a/src/app/contact/contact.ts
+++ b/src/app/contact/contact.ts
@@ -1,0 +1,209 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import {
+  FieldTree,
+  FormField,
+  FormRoot,
+  form,
+  maxLength,
+  minLength,
+  pattern,
+  required,
+  submit,
+} from '@angular/forms/signals';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { ButtonModule } from 'primeng/button';
+import { FloatLabel } from 'primeng/floatlabel';
+import { InputText } from 'primeng/inputtext';
+import { MessageModule } from 'primeng/message';
+import {
+  ContactIssueRequest,
+  ContactIssueResponse,
+  FirebaseService,
+} from '../shared/services/firebase.service';
+import { Header } from '../shared/header/header';
+import { ContactFormModel } from './contact.types';
+
+const GITHUB_USERNAME_PATTERN = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+
+function createInitialModel(): ContactFormModel {
+  return {
+    name: '',
+    githubUsername: '',
+    subject: '',
+    message: '',
+    website: '',
+  };
+}
+
+@Component({
+  selector: 'app-contact',
+  imports: [
+    Header,
+    RouterLink,
+    TranslocoModule,
+    FormRoot,
+    FormField,
+    ButtonModule,
+    FloatLabel,
+    InputText,
+    MessageModule,
+  ],
+  templateUrl: './contact.html',
+  styleUrl: './contact.css',
+})
+export class Contact {
+  private readonly firebaseService = inject(FirebaseService);
+  private readonly translocoService = inject(TranslocoService);
+
+  readonly contactModel = signal<ContactFormModel>(createInitialModel());
+  readonly submitError = signal<string | null>(null);
+  readonly createdIssue = signal<ContactIssueResponse | null>(null);
+
+  readonly contactForm = form(this.contactModel, (contact) => {
+    required(contact.name);
+    maxLength(contact.name, 80);
+    maxLength(contact.githubUsername, 39);
+    pattern(contact.githubUsername, GITHUB_USERNAME_PATTERN, {
+      when: ({ value }) => value().trim().length > 0,
+    });
+    required(contact.subject);
+    maxLength(contact.subject, 120);
+    required(contact.message);
+    minLength(contact.message, 10);
+    maxLength(contact.message, 5000);
+  });
+
+  readonly isSubmitting = computed(() => this.contactForm().submitting());
+
+  async onSubmit(): Promise<void> {
+    this.submitError.set(null);
+    this.createdIssue.set(null);
+    this.contactForm().markAsTouched();
+
+    try {
+      const success = await submit(this.contactForm, async (formState) => {
+        const result = await this.firebaseService.createContactIssue(
+          this.buildPayload(formState().value()),
+        );
+        this.createdIssue.set(result);
+      });
+
+      if (!success) {
+        return;
+      }
+
+      this.contactModel.set(createInitialModel());
+      this.contactForm().reset();
+    } catch (error) {
+      console.error('Contact submission failed', error);
+      this.submitError.set(this.extractSubmitErrorMessage(error));
+    }
+  }
+
+  onReset(): void {
+    this.contactModel.set(createInitialModel());
+    this.contactForm().reset();
+    this.submitError.set(null);
+    this.createdIssue.set(null);
+  }
+
+  showFieldError(field: FieldTree<unknown>): boolean {
+    return field().touched() && field().errors().length > 0;
+  }
+
+  fieldErrorMessage(field: FieldTree<unknown>): string {
+    const error = field().errors()[0];
+
+    if (!error) {
+      return '';
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+
+    switch (error.kind) {
+      case 'required':
+        return this.translocoService.translate('contact.form.errors.required');
+      case 'minLength':
+        return this.translocoService.translate('contact.form.errors.minLength', {
+          count: this.readNumericErrorDetail(error, 'minLength'),
+        });
+      case 'maxLength':
+        return this.translocoService.translate('contact.form.errors.maxLength', {
+          count: this.readNumericErrorDetail(error, 'maxLength'),
+        });
+      case 'pattern':
+        return this.translocoService.translate('contact.form.errors.githubUsername');
+      default:
+        return this.translocoService.translate('contact.form.errors.invalid');
+    }
+  }
+
+  private buildPayload(model: ContactFormModel): ContactIssueRequest {
+    return {
+      name: model.name.trim(),
+      githubUsername: model.githubUsername.trim() || undefined,
+      subject: model.subject.trim(),
+      message: model.message.trim(),
+      locale: this.translocoService.getActiveLang(),
+      website: model.website,
+    };
+  }
+
+  private extractSubmitErrorMessage(error: unknown): string {
+    const details = this.readErrorDetails(error);
+
+    switch (details.code) {
+      case 'functions/unavailable':
+        return this.translocoService.translate('contact.form.submitUnavailable');
+      case 'functions/permission-denied':
+      case 'functions/failed-precondition':
+      case 'functions/invalid-argument':
+      case 'functions/internal':
+        return details.message || this.translocoService.translate('contact.form.submitError');
+      default:
+        return details.message || this.translocoService.translate('contact.form.submitError');
+    }
+  }
+
+  private readErrorDetails(error: unknown): { code?: string; message?: string } {
+    if (!error || typeof error !== 'object') {
+      return {};
+    }
+
+    const details = error as Record<string, unknown>;
+    const code = typeof details['code'] === 'string' ? details['code'] : undefined;
+    const rawMessage = typeof details['message'] === 'string' ? details['message'] : undefined;
+
+    return {
+      code,
+      message: this.normalizeErrorMessage(rawMessage),
+    };
+  }
+
+  private normalizeErrorMessage(message: string | undefined): string | undefined {
+    if (!message) {
+      return undefined;
+    }
+
+    return message
+      .replace(/^FirebaseError:\s*/i, '')
+      .replace(/^Error:\s*/i, '')
+      .trim();
+  }
+
+  private readNumericErrorDetail(error: object, key: 'minLength' | 'maxLength'): number {
+    const details = error as Record<string, unknown>;
+
+    if (key in details) {
+      const value = details[key];
+      if (typeof value === 'number') {
+        return value;
+      }
+    }
+
+    return 0;
+  }
+}

--- a/src/app/contact/contact.types.ts
+++ b/src/app/contact/contact.types.ts
@@ -1,0 +1,7 @@
+export interface ContactFormModel {
+  name: string;
+  githubUsername: string;
+  subject: string;
+  message: string;
+  website: string;
+}

--- a/src/app/faq/faq.css
+++ b/src/app/faq/faq.css
@@ -1,0 +1,5 @@
+.faq-answer {
+  color: var(--p-text-muted-color);
+  line-height: 1.6;
+  white-space: pre-line;
+}

--- a/src/app/faq/faq.html
+++ b/src/app/faq/faq.html
@@ -1,0 +1,39 @@
+<app-header />
+
+<main class="max-w-[960px] mx-auto px-4 py-8 flex flex-col gap-8">
+  <section
+    class="rounded-[var(--p-border-radius-xl)] bg-[var(--p-surface-card)] p-6 shadow-[var(--p-card-shadow)]"
+  >
+    <div class="flex flex-col gap-4">
+      <p class="m-0 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--p-primary-color)]">
+        {{ 'faq.eyebrow' | transloco }}
+      </p>
+      <h1 class="m-0 text-[2rem] font-bold">{{ 'faq.title' | transloco }}</h1>
+      <p class="m-0 text-[var(--p-text-muted-color)] text-lg">
+        {{ 'faq.intro' | transloco }}
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <p-button [label]="'faq.actions.contact' | transloco" routerLink="/contact" />
+        <p-button
+          [label]="'faq.actions.home' | transloco"
+          severity="secondary"
+          [outlined]="true"
+          routerLink="/"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <p-accordion value="overview">
+      @for (item of items(); track item) {
+        <p-accordion-panel [value]="item">
+          <p-accordion-header>{{ ('faq.items.' + item + '.question') | transloco }}</p-accordion-header>
+          <p-accordion-content>
+            <p class="m-0 faq-answer">{{ ('faq.items.' + item + '.answer') | transloco }}</p>
+          </p-accordion-content>
+        </p-accordion-panel>
+      }
+    </p-accordion>
+  </section>
+</main>

--- a/src/app/faq/faq.spec.ts
+++ b/src/app/faq/faq.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { providePrimeNG } from 'primeng/config';
+import { provideTranslocoTesting } from '../testing/transloco-testing.providers';
+import { Faq } from './faq';
+
+describe('Faq', () => {
+  let component: Faq;
+  let fixture: ComponentFixture<Faq>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Faq],
+      providers: [provideRouter([]), providePrimeNG({}), ...provideTranslocoTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Faq);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the FAQ title', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('FAQ');
+  });
+
+  it('should expose FAQ entries built from product features', () => {
+    expect(component.items().length).toBe(7);
+  });
+});

--- a/src/app/faq/faq.ts
+++ b/src/app/faq/faq.ts
@@ -1,0 +1,24 @@
+import { Component, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { AccordionModule } from 'primeng/accordion';
+import { ButtonModule } from 'primeng/button';
+import { Header } from '../shared/header/header';
+
+@Component({
+  selector: 'app-faq',
+  imports: [Header, RouterLink, TranslocoModule, AccordionModule, ButtonModule],
+  templateUrl: './faq.html',
+  styleUrl: './faq.css',
+})
+export class Faq {
+  readonly items = signal([
+    'overview',
+    'formats',
+    'live',
+    'roles',
+    'calendar',
+    'yaml',
+    'languages',
+  ]);
+}

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -85,6 +85,40 @@
     </div>
   </section>
 
+  <section class="mt-12 px-4">
+    <div
+      class="rounded-[var(--p-border-radius-xl)] border border-[var(--p-surface-border)] bg-[var(--p-surface-card)] p-6"
+    >
+      <div class="flex flex-col gap-2 mb-6">
+        <h2 class="text-[1.75rem] font-semibold m-0">{{ 'home.help.title' | transloco }}</h2>
+        <p class="m-0 opacity-80">{{ 'home.help.description' | transloco }}</p>
+      </div>
+
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-4">
+        @for (link of helpLinks(); track link.route) {
+          <p-card class="feature-card">
+            <div class="flex flex-col items-start gap-4 p-2 h-full">
+              <app-svg-icon
+                [name]="link.icon"
+                class="text-[2rem] text-[var(--p-primary-color)] block"
+              />
+              <div class="flex flex-col gap-2">
+                <h3 class="text-[1.1rem] font-semibold m-0">{{ link.titleKey | transloco }}</h3>
+                <p class="opacity-80 m-0">{{ link.descriptionKey | transloco }}</p>
+              </div>
+              <p-button
+                [label]="link.actionLabelKey | transloco"
+                severity="secondary"
+                [outlined]="true"
+                [routerLink]="link.route"
+              />
+            </div>
+          </p-card>
+        }
+      </div>
+    </div>
+  </section>
+
   <!-- Tournament List -->
   <section class="mt-12">
     <div class="flex justify-between items-center mb-4 px-4">

--- a/src/app/home/home.ts
+++ b/src/app/home/home.ts
@@ -15,6 +15,14 @@ interface Feature {
   descriptionKey: string;
 }
 
+interface HelpLink {
+  icon: SvgIconName;
+  titleKey: string;
+  descriptionKey: string;
+  actionLabelKey: string;
+  route: string;
+}
+
 @Component({
   selector: 'app-home',
   imports: [RouterLink, ButtonModule, CardModule, TournamentsTable, HeaderActions, TranslocoModule, SvgIcon],
@@ -72,6 +80,23 @@ export class Home {
       icon: 'code',
       titleKey: 'home.features.openSource.title',
       descriptionKey: 'home.features.openSource.description',
+    },
+  ]);
+
+  helpLinks = signal<HelpLink[]>([
+    {
+      icon: 'list',
+      titleKey: 'home.help.faq.title',
+      descriptionKey: 'home.help.faq.description',
+      actionLabelKey: 'home.help.faq.action',
+      route: '/faq',
+    },
+    {
+      icon: 'users',
+      titleKey: 'home.help.contact.title',
+      descriptionKey: 'home.help.contact.description',
+      actionLabelKey: 'home.help.contact.action',
+      route: '/contact',
     },
   ]);
 

--- a/src/app/shared/services/firebase.service.ts
+++ b/src/app/shared/services/firebase.service.ts
@@ -699,7 +699,9 @@ export class FirebaseService {
 
   async createContactIssue(payload: ContactIssueRequest): Promise<ContactIssueResponse> {
     if (!this.functions) {
-      throw new Error('Functions unavailable');
+      const error = new Error('Functions unavailable') as Error & { code: string };
+      error.code = 'functions/unavailable';
+      throw error;
     }
 
     const callable = httpsCallable<ContactIssueRequest, ContactIssueResponse>(

--- a/src/app/shared/services/firebase.service.ts
+++ b/src/app/shared/services/firebase.service.ts
@@ -27,6 +27,20 @@ import { Game, Team, TimeSlot } from '../../tournaments/models';
 import { environment } from '../../../environments/environment';
 import { getPlayoffRoundKey } from '../utils/playoff-label';
 
+export interface ContactIssueRequest {
+  name: string;
+  githubUsername?: string;
+  subject: string;
+  message: string;
+  locale: string;
+  website?: string;
+}
+
+export interface ContactIssueResponse {
+  issueNumber: number;
+  issueUrl: string;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -681,6 +695,20 @@ export class FirebaseService {
       ...(databaseId !== '(default)' ? { databaseId } : {}),
     });
     return result.data.proposedTimeSlots;
+  }
+
+  async createContactIssue(payload: ContactIssueRequest): Promise<ContactIssueResponse> {
+    if (!this.functions) {
+      throw new Error('Functions unavailable');
+    }
+
+    const callable = httpsCallable<ContactIssueRequest, ContactIssueResponse>(
+      this.functions,
+      'createContactIssue',
+    );
+    const result = await callable(payload);
+
+    return result.data;
   }
 
   getCalendarUrl(tournamentId: string, teamId?: string | null, lang?: string): string {


### PR DESCRIPTION
This adds two public product pages that help visitors understand the app and get in touch without leaving the site. The goal is to improve discoverability from the home page and turn contact requests into trackable support items.

## What changed

- adds public `/faq` and `/contact` routes and links to them from the home page
- adds a FAQ page built around the features already present in the app: tournament formats, live scores, URL-based roles, YAML import/export, calendar export, multilingual support, and open source positioning
- adds a contact page using an Angular signal form with validation, translated copy, and clearer error feedback
- adds a Firebase Function that creates GitHub issues from contact submissions and applies the `contact` label
- wires the frontend service layer to the new function and adds tests for the new pages and contact flow

## Notes for review

- the contact form now surfaces backend error messages such as missing `GITHUB_CONTACT_TOKEN`, invalid GitHub token permissions, or unavailable Functions, instead of only showing a generic failure message
- the GitHub issue creation flow expects `GITHUB_CONTACT_TOKEN` to be configured in Firebase Functions and uses a honeypot field for basic spam protection
- no PR template was present in `.github/`, so this description is freeform